### PR TITLE
Task126 split2

### DIFF
--- a/Druid-Tests/DRAbstractMockTest.class.st
+++ b/Druid-Tests/DRAbstractMockTest.class.st
@@ -14,7 +14,28 @@ Class {
 { #category : #initialization }
 DRAbstractMockTest >> jitCompilerClassForTest [
 
+	^ testingEnvironment 
+		at: self jitCompilerClassNameForTest 
+		ifAbsent: [ 
+			Smalltalk image classInstaller make: [ : builder |
+				builder
+					name: self jitCompilerClassNameForTest;
+					superclass: self jitSuperclassForTest;
+					category: self jitCompilerClassNameForTest ]. ]
+
+
+]
+
+{ #category : #running }
+DRAbstractMockTest >> jitCompilerClassNameForTest [ 
+
 	^ #MyJITCompilerClass
+]
+
+{ #category : #running }
+DRAbstractMockTest >> jitSuperclassForTest [
+
+	^ CogVMSimulatorLSB
 ]
 
 { #category : #running }

--- a/Druid-Tests/DRDispatchTableBuilderTest.class.st
+++ b/Druid-Tests/DRDispatchTableBuilderTest.class.st
@@ -1,0 +1,44 @@
+"
+A DRCogitPrimitiveDumperTest is a test class for testing the behavior of DRCogitPrimitiveDumper
+"
+Class {
+	#name : #DRDispatchTableBuilderTest,
+	#superclass : #DRAbstractMockTest,
+	#instVars : [
+		'dispatchTableBuilder'
+	],
+	#category : #'Druid-Tests-InterpreterBuilder'
+}
+
+{ #category : #running }
+DRDispatchTableBuilderTest >> compilationUnitForTesting [
+
+	^ DRCompilationUnit new
+		targetClass: self jitCompilerClassForTest;
+		yourself
+]
+
+{ #category : #initialization }
+DRDispatchTableBuilderTest >> jitCompilerClassForTest [
+
+	^ interpreter environmentAt: super jitCompilerClassForTest
+]
+
+{ #category : #running }
+DRDispatchTableBuilderTest >> setUp [
+
+	super setUp.
+	interpreter :=	DRInterpreterToCompiler fromInterpreterBuilder: (self interpreterWith: #(#primitiveAdd #primitiveEqual)).
+	dispatchTableBuilder := DRCogitDispatchTableBuilder primitiveTableMethodFrom: self compilationUnitForTesting
+]
+
+{ #category : #tests }
+DRDispatchTableBuilderTest >> testCollectAllMethodsOn [
+
+	| pcgMethodNodes |
+	self assert: dispatchTableBuilder initPrimitiveTable isEmpty.
+	pcgMethodNodes := dispatchTableBuilder collectAllMethodsOn: self jitCompilerClassForTest class.
+	self
+		assertCollection: (pcgMethodNodes collect: #selector)
+		hasSameElements: #(primitiveTableArray initializePrimitiveTable)
+]

--- a/Druid-Tests/DRDispatchTableBuilderTest.class.st
+++ b/Druid-Tests/DRDispatchTableBuilderTest.class.st
@@ -13,22 +13,16 @@ Class {
 { #category : #running }
 DRDispatchTableBuilderTest >> compilationUnitForTesting [
 
-	^ DRCompilationUnit new
+	^ DRPrimitiveCompilationUnit new
 		targetClass: self jitCompilerClassForTest;
 		yourself
-]
-
-{ #category : #initialization }
-DRDispatchTableBuilderTest >> jitCompilerClassForTest [
-
-	^ interpreter environmentAt: super jitCompilerClassForTest
 ]
 
 { #category : #running }
 DRDispatchTableBuilderTest >> setUp [
 
 	super setUp.
-	interpreter :=	DRInterpreterToCompiler fromInterpreterBuilder: (self interpreterWith: #(#primitiveAdd #primitiveEqual)).
+	interpreter :=	DRInterpreterToCompiler fromInterpreterClass: DRBasicCogInterpreterArithmeticPrimitives.
 	dispatchTableBuilder := DRCogitDispatchTableBuilder primitiveTableMethodFrom: self compilationUnitForTesting
 ]
 

--- a/Druid-Tests/DREmptyInterpreter.class.st
+++ b/Druid-Tests/DREmptyInterpreter.class.st
@@ -13,3 +13,10 @@ DREmptyInterpreter class >> basicPrimitiveTable [
 
 	^ Array empty
 ]
+
+{ #category : #'class initialization' }
+DREmptyInterpreter class >> primitiveTableArray [
+
+	<generated>
+	^ { { 0. 0 } }
+]

--- a/Druid-Tests/DRInterpreterBuilderTest.class.st
+++ b/Druid-Tests/DRInterpreterBuilderTest.class.st
@@ -10,7 +10,14 @@ Class {
 { #category : #tests }
 DRInterpreterBuilderTest >> interpreterClassForTest [
 
-	^ testingEnvironment at: self interpreterClassNameForTest 
+	^ testingEnvironment 
+		at: self interpreterClassNameForTest 
+		ifAbsent: [ 
+			Smalltalk image classInstaller make: [ : builder |
+				builder
+					name: self interpreterClassNameForTest;
+					superclass: self interpreterSuperclassForTest;
+					category: self interpreterClassNameForTest ]. ]
 ]
 
 { #category : #tests }
@@ -20,11 +27,17 @@ DRInterpreterBuilderTest >> interpreterClassNameForTest [
 ]
 
 { #category : #running }
+DRInterpreterBuilderTest >> interpreterSuperclassForTest [
+
+	^ DRBasicCogInterpreterArithmeticPrimitives
+]
+
+{ #category : #running }
 DRInterpreterBuilderTest >> setUp [
 
 	super setUp.
 	interpreterToCompiler := DRInterpreterBuilderToCompiler new
-		targetSuperclass: DRBasicCogInterpreterArithmeticPrimitives;
+		targetSuperclass: self interpreterSuperclassForTest;
 		yourself.
 
 ]
@@ -32,8 +45,11 @@ DRInterpreterBuilderTest >> setUp [
 { #category : #running }
 DRInterpreterBuilderTest >> tearDown [
 
-	druidInterpreter
-		ifNotNil: [ testingEnvironment removeClassNamed: druidInterpreter class name ].
+	interpreterToCompiler targetClass ifNotNil: [ : tc | 
+		(RGContainer packageOfClass: tc) realPackage removeFromSystem ].
+
+	SystemOrganizer default removeSystemCategory: druidInterpreter class name.
+	testingEnvironment removeClassNamed: druidInterpreter class name.
 	super tearDown
 ]
 
@@ -53,10 +69,26 @@ DRInterpreterBuilderTest >> testAddPrimitives [
 		assert: (interpreterToCompiler primitives allSatisfy: [ : p | p isKindOf: DRPrimitiveObject ])
 ]
 
-{ #category : #tests }
-DRInterpreterBuilderTest >> testCompilationUnitPopulateInitializePrimitiveTable [
+{ #category : #initialization }
+DRInterpreterBuilderTest >> testCompilePrimitive [
 
-	interpreterToCompiler generateIRAndCompileIn: self interpreterClassNameForTest.
+	| primitives |
+	interpreterToCompiler addPrimitives: #(#primitiveAdd).
+	primitives := interpreterToCompiler primitives.
+	self assert: primitives notEmpty.
+	self
+		assert: primitives anyOne sourceSelector
+		equals: #primitiveAdd.
+	interpreterToCompiler compileAll.
+	self
+		assertCollection: interpreterToCompiler interpreterClass primitiveTable
+		hasSameElements: #(0 #primitiveAdd #primitiveFail)
+]
+
+{ #category : #tests }
+DRInterpreterBuilderTest >> testCompilePrimitiveTable [
+
+	interpreterToCompiler buildIRAndCompileIn: self interpreterClassNameForTest.
 
 	self assert: interpreterToCompiler initPrimitiveTable notEmpty
 ]
@@ -64,25 +96,23 @@ DRInterpreterBuilderTest >> testCompilationUnitPopulateInitializePrimitiveTable 
 { #category : #tests }
 DRInterpreterBuilderTest >> testConfigureInterpreterClass [
 
-	interpreterToCompiler targetClass: self interpreterClassNameForTest.
-	self deny: (interpreterToCompiler targetClass respondsTo: #basicPrimitiveTable).
+	interpreterToCompiler targetClass: self interpreterClassForTest.
+
+	self 
+		assertCollection: interpreterToCompiler targetClass basicPrimitiveTable 
+		hasSameElements: #(0 #primitiveAdd #primitiveSubtract #primitiveLessThan #primitiveGreaterThan #primitiveLessOrEqual #primitiveGreaterOrEqual #primitiveEqual #primitiveNotEqual #primitiveMultiply #primitiveDivide).
 	
 	interpreterToCompiler 
 		addPrimitives: #(#primitiveAdd);
 		compileAll.
-	self assert: (interpreterToCompiler targetClass respondsTo: #basicPrimitiveTable).
+	self assert: interpreterToCompiler primitives notEmpty.
+	self assert: (interpreterToCompiler primitives anyOne isKindOf: DRPrimitiveObject).
+	self assert: interpreterToCompiler primitives anyOne sourceSelector equals: #primitiveAdd
 	
 ]
 
-{ #category : #tests }
-DRInterpreterBuilderTest >> testGenerateEmptyCompilationUnit [
-
-	interpreterToCompiler := interpreterToCompiler primitives: Array empty.
-	self assertEmpty: interpreterToCompiler primitives.
-]
-
 { #category : #initialization }
-DRInterpreterBuilderTest >> testGenerateMultiplePrimitiveObjectCompilationUnit [
+DRInterpreterBuilderTest >> testCountPrimimitives [
 
 	interpreterToCompiler targetClass: self interpreterClassForTest.
 	self 
@@ -91,19 +121,15 @@ DRInterpreterBuilderTest >> testGenerateMultiplePrimitiveObjectCompilationUnit [
 	interpreterToCompiler addPrimitives: #(#primitiveAdd) .
 	self
 		assert: interpreterToCompiler primitives size 
-		equals: interpreterToCompiler primitivesCount
+		equals: 1.
+	self
+		assert:  interpreterToCompiler primitivesCount
+		equals: 10.
 ]
 
-{ #category : #initialization }
-DRInterpreterBuilderTest >> testGenerateSinglePrimitiveCompilationUnit [
+{ #category : #tests }
+DRInterpreterBuilderTest >> testGenerateEmptyCompilationUnit [
 
-	| primitives |
-	interpreterToCompiler primitives: #(#primitiveAdd).
-	primitives := interpreterToCompiler primitives.
-	self
-		assert: primitives notEmpty;
-		assert: (primitives anyOne isKindOf: DRPrimitiveObject).
-	self
-		assertCollection: (primitives collect: #sourceSelector)
-		hasSameElements: #(primitiveAdd)
+	interpreterToCompiler := interpreterToCompiler primitives: Array empty.
+	self assertEmpty: interpreterToCompiler primitives.
 ]

--- a/Druid-Tests/DRInterpreterBuilderTest.class.st
+++ b/Druid-Tests/DRInterpreterBuilderTest.class.st
@@ -1,0 +1,109 @@
+Class {
+	#name : #DRInterpreterBuilderTest,
+	#superclass : #DRInterpreterToCompilerTest,
+	#instVars : [
+		'druidInterpreter'
+	],
+	#category : #'Druid-Tests-InterpreterBuilder'
+}
+
+{ #category : #tests }
+DRInterpreterBuilderTest >> interpreterClassForTest [
+
+	^ testingEnvironment at: self interpreterClassNameForTest 
+]
+
+{ #category : #tests }
+DRInterpreterBuilderTest >> interpreterClassNameForTest [
+
+	^ #DRNewInterpreterForTest
+]
+
+{ #category : #running }
+DRInterpreterBuilderTest >> setUp [
+
+	super setUp.
+	interpreterToCompiler := DRInterpreterBuilderToCompiler new
+		targetSuperclass: DRBasicCogInterpreterArithmeticPrimitives;
+		yourself.
+
+]
+
+{ #category : #running }
+DRInterpreterBuilderTest >> tearDown [
+
+	druidInterpreter
+		ifNotNil: [ testingEnvironment removeClassNamed: druidInterpreter class name ].
+	super tearDown
+]
+
+{ #category : #tests }
+DRInterpreterBuilderTest >> testAddPrimitives [
+
+	| primitiveSet |
+	primitiveSet := #(#primitiveAdd #primitiveEqual).
+	druidInterpreter := interpreterToCompiler newInterpreter.
+	interpreterToCompiler addPrimitives: primitiveSet.
+
+	self
+		assertCollection: (interpreterToCompiler primitives collect: #sourceSelector)
+		hasSameElements: primitiveSet.
+
+	self
+		assert: (interpreterToCompiler primitives allSatisfy: [ : p | p isKindOf: DRPrimitiveObject ])
+]
+
+{ #category : #tests }
+DRInterpreterBuilderTest >> testCompilationUnitPopulateInitializePrimitiveTable [
+
+	interpreterToCompiler generateIRAndCompileIn: self interpreterClassNameForTest.
+
+	self assert: interpreterToCompiler initPrimitiveTable notEmpty
+]
+
+{ #category : #tests }
+DRInterpreterBuilderTest >> testConfigureInterpreterClass [
+
+	interpreterToCompiler targetClass: self interpreterClassNameForTest.
+	self deny: (interpreterToCompiler targetClass respondsTo: #basicPrimitiveTable).
+	
+	interpreterToCompiler 
+		addPrimitives: #(#primitiveAdd);
+		compileAll.
+	self assert: (interpreterToCompiler targetClass respondsTo: #basicPrimitiveTable).
+	
+]
+
+{ #category : #tests }
+DRInterpreterBuilderTest >> testGenerateEmptyCompilationUnit [
+
+	interpreterToCompiler := interpreterToCompiler primitives: Array empty.
+	self assertEmpty: interpreterToCompiler primitives.
+]
+
+{ #category : #initialization }
+DRInterpreterBuilderTest >> testGenerateMultiplePrimitiveObjectCompilationUnit [
+
+	interpreterToCompiler targetClass: self interpreterClassForTest.
+	self 
+		assert: interpreterToCompiler primitives size 
+		equals: 0.
+	interpreterToCompiler addPrimitives: #(#primitiveAdd) .
+	self
+		assert: interpreterToCompiler primitives size 
+		equals: interpreterToCompiler primitivesCount
+]
+
+{ #category : #initialization }
+DRInterpreterBuilderTest >> testGenerateSinglePrimitiveCompilationUnit [
+
+	| primitives |
+	interpreterToCompiler primitives: #(#primitiveAdd).
+	primitives := interpreterToCompiler primitives.
+	self
+		assert: primitives notEmpty;
+		assert: (primitives anyOne isKindOf: DRPrimitiveObject).
+	self
+		assertCollection: (primitives collect: #sourceSelector)
+		hasSameElements: #(primitiveAdd)
+]

--- a/Druid-Tests/DRInterpreterToCompilerTest.class.st
+++ b/Druid-Tests/DRInterpreterToCompilerTest.class.st
@@ -20,7 +20,7 @@ DRInterpreterToCompilerTest >> testAddPrimitives [
 	| primitiveSet |
 	primitiveSet := #(#primitiveAdd #primitiveSubtract #primitiveLessThan #primitiveGreaterThan #primitiveLessOrEqual #primitiveGreaterOrEqual #primitiveEqual #primitiveNotEqual #primitiveMultiply #primitiveDivide).
 	
-	interpreterToCompiler generateIRAndCompileIn: self jitCompilerClassForTest.
+	interpreterToCompiler buildIRAndCompileIn: self jitCompilerClassNameForTest.
 	self
 		assertCollection: (interpreterToCompiler primitives collect: #sourceSelector)
 		hasSameElements: primitiveSet.
@@ -30,9 +30,9 @@ DRInterpreterToCompilerTest >> testAddPrimitives [
 ]
 
 { #category : #tests }
-DRInterpreterToCompilerTest >> testCompilationUnitPopulateInitializePrimitiveTable [
+DRInterpreterToCompilerTest >> testCompilePrimitiveTable [
 
-	interpreterToCompiler generateIRAndCompileIn: self jitCompilerClassForTest.
+	interpreterToCompiler buildIRAndCompileIn: self jitCompilerClassNameForTest.
 
 	self assert: interpreterToCompiler initPrimitiveTable notEmpty
 ]

--- a/Druid-Tests/DRInterpreterToCompilerTest.class.st
+++ b/Druid-Tests/DRInterpreterToCompilerTest.class.st
@@ -11,8 +11,22 @@ Class {
 DRInterpreterToCompilerTest >> setUp [
 
 	super setUp.
-	testingEnvironment := Smalltalk globals.
 	interpreterToCompiler := DRInterpreterToCompiler fromInterpreterClass: DRBasicCogInterpreterArithmeticPrimitives
+]
+
+{ #category : #tests }
+DRInterpreterToCompilerTest >> testAddPrimitives [
+
+	| primitiveSet |
+	primitiveSet := #(#primitiveAdd #primitiveSubtract #primitiveLessThan #primitiveGreaterThan #primitiveLessOrEqual #primitiveGreaterOrEqual #primitiveEqual #primitiveNotEqual #primitiveMultiply #primitiveDivide).
+	
+	interpreterToCompiler generateIRAndCompileIn: self jitCompilerClassForTest.
+	self
+		assertCollection: (interpreterToCompiler primitives collect: #sourceSelector)
+		hasSameElements: primitiveSet.
+
+	self
+		assert: (interpreterToCompiler primitives allSatisfy: [ : p | p isKindOf: DRPrimitiveObject ])
 ]
 
 { #category : #tests }
@@ -28,19 +42,4 @@ DRInterpreterToCompilerTest >> testGenerateEmptyCompilationUnit [
 
 	interpreterToCompiler := DRInterpreterToCompiler fromInterpreterClass: DREmptyInterpreter.
 	self assert: interpreterToCompiler primitives isEmpty
-]
-
-{ #category : #tests }
-DRInterpreterToCompilerTest >> testGenerateMultiplePrimitiveCompilationUnit [
-
-	| primitiveSet |
-	primitiveSet := #(#primitiveAdd #primitiveSubtract #primitiveLessThan #primitiveGreaterThan #primitiveLessOrEqual #primitiveGreaterOrEqual #primitiveEqual #primitiveNotEqual #primitiveMultiply #primitiveDivide).
-	
-	interpreterToCompiler generateIRAndCompileIn: self jitCompilerClassForTest.
-	self
-		assertCollection: (interpreterToCompiler primitives collect: #sourceSelector)
-		hasSameElements: primitiveSet.
-
-	self
-		assert: (interpreterToCompiler primitives allSatisfy: [ : p | p isKindOf: DRPrimitiveObject ])
 ]

--- a/Druid-Tests/DRPrimitiveSelectionTest.class.st
+++ b/Druid-Tests/DRPrimitiveSelectionTest.class.st
@@ -14,7 +14,7 @@ DRPrimitiveSelectionTest >> setUp [
 	super setUp.
 	interpreterToCompiler := DRInterpreterToCompiler fromInterpreterClass: DRBasicCogInterpreterArithmeticPrimitives.
 	interpreterToCompiler
-		compilerCompilerClass: #MyJITCompilerClass;
+		targetClass: self jitCompilerClassForTest;
 		targetSuperclass: CogVMSimulatorLSB
 ]
 

--- a/Druid/DRAbstractCompilerBuilder.class.st
+++ b/Druid/DRAbstractCompilerBuilder.class.st
@@ -67,6 +67,13 @@ DRAbstractCompilerBuilder >> targetClass [
 ]
 
 { #category : #accessing }
+DRAbstractCompilerBuilder >> targetClass: aClass [
+	" Set the <Class> which we are building "
+
+	^ self compilationUnit targetClass: aClass
+]
+
+{ #category : #accessing }
 DRAbstractCompilerBuilder >> targetSuperclass [
 
 	^ self compilationUnit targetSuperclass

--- a/Druid/DRAbstractDispatchTableBuilder.class.st
+++ b/Druid/DRAbstractDispatchTableBuilder.class.st
@@ -45,12 +45,32 @@ DRAbstractDispatchTableBuilder >> buildInitializePrimitiveTableAssignmentNode [
 	self subclassResponsibility
 ]
 
+{ #category : #'accessing - building' }
+DRAbstractDispatchTableBuilder >> buildInitializePrimitiveTableIVarAssignmentNode [
+
+	^ PCGAssignmentNode new
+		  variable: self buildPrimitiveTableVariableNode;
+		  value: self buildPrimitiveTableInitialValueNode
+]
+
 { #category : #accessing }
 DRAbstractDispatchTableBuilder >> buildInitializePrimitiveTableMaxCompiledPrimitiveIndexNode [
 
 	^ PCGAssignmentNode new
 		  variable: self maxPrimitiveIndexGlobalName asPCGGlobal;
 		  value: self maxCompiledPrimitives asPCG
+]
+
+{ #category : #'accessing - building' }
+DRAbstractDispatchTableBuilder >> buildInitializePrimitiveTableMethodNode [
+	"Answer a <PCGMethodNode> ready for installation in a JIT compiler class"
+
+	^ (PCGMethodNode selector: self initPrimitiveTableSelector) bodyBlock: [ : body |
+		  body
+			<< self buildInitializePrimitiveTableMaxCompiledPrimitiveIndexNode;
+			<< self buildInitializePrimitiveTableIVarAssignmentNode;
+			<< self buildInitializePrimitiveTableAssignmentNode;
+			<< self buildPrimitiveTableVariableNode returnIt ]
 ]
 
 { #category : #'accessing - building' }

--- a/Druid/DRCogitDispatchTableBuilder.class.st
+++ b/Druid/DRCogitDispatchTableBuilder.class.st
@@ -27,26 +27,6 @@ DRCogitDispatchTableBuilder >> buildInitializePrimitiveTableAssignmentNode [
 			arguments: { self buildPrimitiveTableVariableNode . #'self primitiveTableArray' asPCGArgument }
 ]
 
-{ #category : #'accessing - building' }
-DRCogitDispatchTableBuilder >> buildInitializePrimitiveTableIVarAssignmentNode [
-
-	^ PCGAssignmentNode new
-		  variable: self buildPrimitiveTableVariableNode;
-		  value: self buildPrimitiveTableInitialValueNode
-]
-
-{ #category : #'accessing - building' }
-DRCogitDispatchTableBuilder >> buildInitializePrimitiveTableMethodNode [
-	"Answer a <PCGMethodNode> ready for installation in a JIT compiler class"
-
-	^ (PCGMethodNode selector: self initPrimitiveTableSelector) bodyBlock: [ : body |
-		  body
-			<< self buildInitializePrimitiveTableMaxCompiledPrimitiveIndexNode;
-			<< self buildInitializePrimitiveTableIVarAssignmentNode;
-			<< self buildInitializePrimitiveTableAssignmentNode;
-			<< self buildPrimitiveTableVariableNode returnIt ]
-]
-
 { #category : #accessing }
 DRCogitDispatchTableBuilder >> buildPrimitiveTableInitialValueNode [
 

--- a/Druid/DRCompilationUnit.class.st
+++ b/Druid/DRCompilationUnit.class.st
@@ -51,6 +51,12 @@ DRCompilationUnit >> compilerBuilder: anObject [
 ]
 
 { #category : #accessing }
+DRCompilationUnit >> defaultTargetSuperclass [
+
+	^ StackToRegisterMappingCogit
+]
+
+{ #category : #accessing }
 DRCompilationUnit >> targetClass [
 	" Answer a <Class> which is the where the methods will be stored "
 
@@ -68,6 +74,7 @@ DRCompilationUnit >> targetSuperclass [
 	" Answer a <Class> acting as the receiver's superclass for compilation "
 
 	^ targetSuperclass
+		ifNil: [ targetSuperclass := self defaultTargetSuperclass ]
 ]
 
 { #category : #accessing }

--- a/Druid/DRDispatchTable.class.st
+++ b/Druid/DRDispatchTable.class.st
@@ -1,0 +1,130 @@
+"
+Implements a model for a dispatch table which provides:
+
+- Specifying a `Collection` of primitives to work with: 
+  - `DRDispatchTable>>#primitives:`
+  - Primitives from a ""source"" class `interpreterClass:` and `DRDispatchTable>>addFromProtocol:` 
+- A protocol to search and filter primitives:
+  - `allSelectorsMatching:` , `allMethodsMatching:`.
+- Generation of the table in a class passed as parameter. `DRDispatchTable>>#generateInterpreterTableIn:` 
+
+## Filtering
+
+To filter primitives by name, one could specify the method of matching, currently supported:
+
+- #beginsWith: _(default)_
+- #matchesRegex:
+
+## Examples
+
+```smalltalk
+
+| dTable |
+""Instantiate a dispatch table for primitives in the Stack Interpreter""
+dTable := DRDispatchTable for: StackInterpreterPrimitives.
+
+""Query and get a Collection with all the primitives starting with 'prim'""
+dTable selectorsMatching: 'prim'.
+
+""Query primitives ending with 'Add'""
+dTable useRegEx.
+dTable selectorsMatching: '.*Add'.
+
+""Add primitives to the receiver from a protocol""
+dTable addFromProtocol: 'arithmetic float primitives'.
+dTable primitives.
+
+```
+
+
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	allowDuplicates:		<Object>
+	excludeObjectClass:		<Object>
+	interpreterClass:		<Object>
+	matchMethod:		<Object>
+	primitives:		<Object>
+	scanSuperclasses:		<Object>
+
+
+    Implementation Points
+"
+Class {
+	#name : #DRDispatchTable,
+	#superclass : #Object,
+	#instVars : [
+		'interpreterClass'
+	],
+	#category : #'Druid-CompilerBuilder'
+}
+
+{ #category : #examples }
+DRDispatchTable class >> example [
+
+	| dispatchTable |
+
+	dispatchTable := DRDispatchTable for: StackInterpreterPrimitives. "InterpreterPrimitives"
+	dispatchTable := DRDispatchTable for: StackInterpreterPrimitives.
+	dispatchTable := DRDispatchTable for: StackInterpreter.
+	"dispatchTable := DRDispatchTable for: CoInterpreter." 
+	dispatchTable addFromSelectorPattern: 'prim'.
+	dispatchTable addFromProtocol: ''.
+	dispatchTable addFromProtocol: 'arithmetic float primitives'.
+	dispatchTable addFromProtocols: #(
+		'arithmetic float primitives' 
+		'control primitives').
+	" Obtain the Dictionary of primitives "
+	dispatchTable methods.
+	dispatchTable generateInterpreterTableIn: #TargetClass.
+]
+
+{ #category : #'instance creation' }
+DRDispatchTable class >> for: anInterpreterClass [
+
+	^ self new
+		initializeFor: anInterpreterClass;
+		yourself
+]
+
+{ #category : #accessing }
+DRDispatchTable >> addFromProtocol: aString [
+	" Add all methods from the protocol named aString in the receiver's interpreter classs"
+
+	aString ifEmpty: [ ^ self ].
+	(self interpreterProtocol hasProtocolNamed: aString)
+		ifTrue: [ self methods addAll: (self interpreterProtocol methodsInProtocolNamed: aString) ]
+]
+
+{ #category : #accessing }
+DRDispatchTable >> addFromProtocols: aCollectionOfProtocolNames [
+	" Add all methods from the protocol named aString in the receiver's interpreter classs"
+
+	aCollectionOfProtocolNames
+		do: [ : protocolName | self addFromProtocol: protocolName ]
+		displayingProgress: [ : name | 'Adding primitives in ' , name ]
+]
+
+{ #category : #accessing }
+DRDispatchTable >> generateInterpreterTableIn: aClassName [
+
+	self shouldBeImplemented
+]
+
+{ #category : #initialization }
+DRDispatchTable >> initializeFor: anInterpreterClass [
+
+	interpreterClass := anInterpreterClass
+]
+
+{ #category : #accessing }
+DRDispatchTable >> interpreterClass [
+	^ interpreterClass
+]
+
+{ #category : #private }
+DRDispatchTable >> interpreterProtocol [
+	" Answer the <ProtocolOrganizer> for the receiver's interpreter "
+
+	^ self targetClass organization protocolOrganizer
+]

--- a/Druid/DRInterpreterBuilderToCompiler.class.st
+++ b/Druid/DRInterpreterBuilderToCompiler.class.st
@@ -1,0 +1,107 @@
+Class {
+	#name : #DRInterpreterBuilderToCompiler,
+	#superclass : #DRInterpreterToCompiler,
+	#instVars : [
+		'interpreter'
+	],
+	#category : #'Druid-CompilerBuilder'
+}
+
+{ #category : #'accessing - primitives' }
+DRInterpreterBuilderToCompiler >> addPrimitives: aCollection [
+	" Add primitives from aCollection of <Symbol> representing primitive selectors "
+
+	self compilationUnit addPrimitives: aCollection
+
+]
+
+{ #category : #'accessing - compiler' }
+DRInterpreterBuilderToCompiler >> compilationUnitClass [
+
+	^ DRStackCompilationUnit
+]
+
+{ #category : #compiling }
+DRInterpreterBuilderToCompiler >> compileAll [
+
+	self newInterpreter.
+	self compilationUnit 
+			compiler: self compilerCompiler;
+			compileAll
+]
+
+{ #category : #initialization }
+DRInterpreterBuilderToCompiler >> initialize [
+
+	super initialize.
+	compilationUnit := DRStackCompilationUnit new
+		dispatchTableBuilder: DRStackInterpreterDispatchTableBuilder new;
+		yourself
+]
+
+{ #category : #accessing }
+DRInterpreterBuilderToCompiler >> interpreterPrimitiveTable [
+	"Answer a <Collection> of <Symbol> each one representing a selector (e.g. #primitiveEqual) of the receiver's primitive table"
+
+	^  interpreter primitiveTable
+]
+
+{ #category : #'instance creation' }
+DRInterpreterBuilderToCompiler >> newInterpreter [
+	" Answer a new <AbstractInterpreter|StackInterpreter> instance "
+	
+	memory := self newMemory.
+	self targetSuperclass
+		ifNil: [ 	self targetSuperclass: CogVMSimulatorLSB ].
+	self targetClass
+		ifNil: [ self targetClass: self newRandomTargetInterpreterClass ].
+	interpreter := self targetClass basicNew
+		  objectMemory: memory;
+		  basicInitialize.
+	^ interpreter
+]
+
+{ #category : #'instance creation' }
+DRInterpreterBuilderToCompiler >> newRandomInterpreterClassName [
+	" Answer a <String> representing a new class name to be used as interpreter containing a #basicPrimitiveTable"
+
+	^ String streamContents: [ : stream |
+		stream 
+			<< self newclassPrefix;
+			<< (UUIDGenerator next asString copyUpTo: $-) ]
+]
+
+{ #category : #'instance creation' }
+DRInterpreterBuilderToCompiler >> newRandomTargetInterpreterClass [
+	" Answer a new <Class> prefixed with receiver's class prefix and following a random name "
+
+	^ Smalltalk image classInstaller make: [ : builder |
+			builder
+				name: self newRandomInterpreterClassName;
+				superclass: self targetSuperclass;
+				category: self newRandomInterpreterClassName ].
+]
+
+{ #category : #'instance creation' }
+DRInterpreterBuilderToCompiler >> newclassPrefix [
+
+	^ #DRInterpreter
+]
+
+{ #category : #'accessing - primitives' }
+DRInterpreterBuilderToCompiler >> primitives [
+
+	^ self compilationUnit primitives
+]
+
+{ #category : #'accessing - primitives' }
+DRInterpreterBuilderToCompiler >> primitivesCount [
+	"Answer a <Number> specifying how many primitive methods implements the receiver. Note that primitive table entry with 0 is ignored"
+
+	| primTableSize |
+
+	primTableSize := self primitiveTable size.
+	(self primitiveTable includes: 0)
+		ifTrue: [ ^ primTableSize - 1 ].
+	^ primTableSize
+]

--- a/Druid/DRInterpreterBuilderToCompiler.class.st
+++ b/Druid/DRInterpreterBuilderToCompiler.class.st
@@ -40,6 +40,26 @@ DRInterpreterBuilderToCompiler >> initialize [
 ]
 
 { #category : #accessing }
+DRInterpreterBuilderToCompiler >> interpreter [
+
+	^ interpreter
+]
+
+{ #category : #accessing }
+DRInterpreterBuilderToCompiler >> interpreter: anObject [
+
+	interpreter := anObject
+]
+
+{ #category : #accessing }
+DRInterpreterBuilderToCompiler >> interpreterClass [
+
+	^ self interpreter
+		ifNil: [ super interpreterClass ]
+		ifNotNil: [ : intrp | intrp class ]
+]
+
+{ #category : #accessing }
 DRInterpreterBuilderToCompiler >> interpreterPrimitiveTable [
 	"Answer a <Collection> of <Symbol> each one representing a selector (e.g. #primitiveEqual) of the receiver's primitive table"
 

--- a/Druid/DRInterpreterToCompiler.class.st
+++ b/Druid/DRInterpreterToCompiler.class.st
@@ -39,6 +39,12 @@ DRInterpreterToCompiler class >> fromInterpreterClass: anInterpreterClass [
 ]
 
 { #category : #'accessing - compiler' }
+DRInterpreterToCompiler >> compileAll [
+
+	self generateBuildModel compileAll
+]
+
+{ #category : #'accessing - compiler' }
 DRInterpreterToCompiler >> compilerCompiler [
 	"Answer a Druid compiler configured for the receiver's interpreter builder"
 
@@ -176,6 +182,13 @@ DRInterpreterToCompiler >> primitives [
 	^ self compilationUnit primitives
 		ifEmpty: [ self generateBuildModel primitives ]
 		ifNotEmpty: [ : p | p ]
+]
+
+{ #category : #'accessing - primitives' }
+DRInterpreterToCompiler >> primitives: aCollection [
+
+	self compilationUnit primitives: aCollection.
+
 ]
 
 { #category : #accessing }

--- a/Druid/DRInterpreterToCompiler.class.st
+++ b/Druid/DRInterpreterToCompiler.class.st
@@ -38,10 +38,53 @@ DRInterpreterToCompiler class >> fromInterpreterClass: anInterpreterClass [
 		yourself
 ]
 
+{ #category : #'accessing - model' }
+DRInterpreterToCompiler >> build [
+	"Answer a <DRCompilationUnit>, useful for model manipulation before code dumping"
+
+	self compilationUnit 
+		compiler: self compilerCompiler;
+		addPrimitives.
+	^ self compilationUnit
+]
+
+{ #category : #'accessing - model' }
+DRInterpreterToCompiler >> buildAndCompileIn: aClass [
+	"Generate and install the receiver's primitives into JIT compiler aClass"
+
+	self build
+		interpreter: interpreterClass;
+		targetSuperclass: self targetSuperclass;
+		targetClass: (self environmentAt: aClass);
+		compileAll
+]
+
+{ #category : #'accessing - model' }
+DRInterpreterToCompiler >> buildAndCompileIn: aClass superclass: aSuperclass [
+	"Generate and install the receiver's primitives into JIT compiler aClass"
+
+	self build
+		interpreter: interpreterClass;
+		targetSuperclass: aSuperclass;
+		targetClass: (self environmentAt: aClass);
+		compileAll
+]
+
+{ #category : #'accessing - model' }
+DRInterpreterToCompiler >> buildIRAndCompileIn: aClass [
+	"Generate and install the receiver's primitives into JIT compiler aClass"
+
+	self compilationUnit
+		targetClass: (self environmentAt: aClass);
+		compiler: self compilerCompiler;
+		addPrimitives;
+		compileAll
+]
+
 { #category : #'accessing - compiler' }
 DRInterpreterToCompiler >> compileAll [
 
-	self generateBuildModel compileAll
+	self build compileAll
 ]
 
 { #category : #'accessing - compiler' }
@@ -72,48 +115,6 @@ DRInterpreterToCompiler >> compilerCompilerClass: aClass [
 DRInterpreterToCompiler >> defaultCompilerCompilerClass [
 
 	^ DRPrimitiveCompilerCompiler
-]
-
-{ #category : #'accessing - model' }
-DRInterpreterToCompiler >> generateBuildModel [
-	"Answer a <DRCompilationUnit>, useful for model manipulation before code dumping"
-
-	self compilationUnit 
-		compiler: self compilerCompiler;
-		addPrimitives.
-	^ self compilationUnit
-]
-
-{ #category : #'accessing - model' }
-DRInterpreterToCompiler >> generateBuildModelAndCompileIn: aClass [
-	"Generate and install the receiver's primitives into JIT compiler aClass"
-
-	self generateBuildModel
-		interpreter: interpreterClass;
-		targetClass: (self environmentAt: aClass);
-		compileAll
-]
-
-{ #category : #'accessing - model' }
-DRInterpreterToCompiler >> generateBuildModelAndCompileIn: aClass superclass: aSuperclass [
-	"Generate and install the receiver's primitives into JIT compiler aClass"
-
-	self generateBuildModel
-		interpreter: interpreterClass;
-		targetSuperclass: aSuperclass;
-		targetClass: (self environmentAt: aClass);
-		compileAll
-]
-
-{ #category : #'accessing - model' }
-DRInterpreterToCompiler >> generateIRAndCompileIn: aClass [
-	"Generate and install the receiver's primitives into JIT compiler aClass"
-
-	self compilationUnit
-		targetClass: (self environmentAt: aClass);
-		compiler: self compilerCompiler;
-		addPrimitives;
-		compileAll
 ]
 
 { #category : #helpers }
@@ -173,21 +174,22 @@ DRInterpreterToCompiler >> newMemory [
 DRInterpreterToCompiler >> primitiveTable [
 	"Answer a <Collection> of primitive selectors"
 
-	^ interpreterClass basicPrimitiveTable
+	^ self targetClass basicPrimitiveTable
 ]
 
 { #category : #'accessing - primitives' }
 DRInterpreterToCompiler >> primitives [
 
 	^ self compilationUnit primitives
-		ifEmpty: [ self generateBuildModel primitives ]
+		ifEmpty: [ self build primitives ]
 		ifNotEmpty: [ : p | p ]
 ]
 
 { #category : #'accessing - primitives' }
 DRInterpreterToCompiler >> primitives: aCollection [
+	" Add a <Collection> of primitive selectors to the receiver's compilation unit "
 
-	self compilationUnit primitives: aCollection.
+	self compilationUnit primitives: aCollection asOrderedCollection.
 
 ]
 

--- a/Druid/DRPrimitiveCompilationUnit.class.st
+++ b/Druid/DRPrimitiveCompilationUnit.class.st
@@ -11,7 +11,6 @@ Class {
 	#instVars : [
 		'primitives',
 		'initPrimitiveTable',
-		'interpreter',
 		'dispatchTableBuilder'
 	],
 	#category : #'Druid-CompilerBuilder'
@@ -137,19 +136,19 @@ DRPrimitiveCompilationUnit >> initPrimitiveTable [
 { #category : #accessing }
 DRPrimitiveCompilationUnit >> interpreter [
 
-	^ interpreter
+	^ self compiler interpreter
 ]
 
 { #category : #accessing }
-DRPrimitiveCompilationUnit >> interpreter: aDRBasicInterpreter [ 
+DRPrimitiveCompilationUnit >> interpreterClass [
 
-	interpreter := aDRBasicInterpreter
+	^ self interpreter class
 ]
 
 { #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> interpreterPrimitiveTable [
 
-	^ self targetClass basicPrimitiveTable 
+	^ self interpreterClass basicPrimitiveTable 
 ]
 
 { #category : #testing }

--- a/Druid/DRPrimitiveCompilationUnit.class.st
+++ b/Druid/DRPrimitiveCompilationUnit.class.st
@@ -12,13 +12,12 @@ Class {
 		'primitives',
 		'initPrimitiveTable',
 		'interpreter',
-		'dispatchTableBuilder',
-		'primitiveMethods'
+		'dispatchTableBuilder'
 	],
 	#category : #'Druid-CompilerBuilder'
 }
 
-{ #category : #accessing }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> addPrimitive: aString [
 
 	(self isValidPrimitiveName: aString)
@@ -26,7 +25,7 @@ DRPrimitiveCompilationUnit >> addPrimitive: aString [
 
 ]
 
-{ #category : #'accessing - compiler' }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> addPrimitiveEntries [
 	"As part of the build unit, add the receiver's primitives from its <Collection> of <DRPrimitiveObject>"
 
@@ -36,7 +35,7 @@ DRPrimitiveCompilationUnit >> addPrimitiveEntries [
 		self addPrimitiveEntry: primitiveObject ]
 ]
 
-{ #category : #'accessing - compiler' }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> addPrimitiveEntry: aDRPrimitiveObject [
 	"Add a primitive entry compatible with the expected format from #initializePrimitiveTable implementation"
 
@@ -47,7 +46,7 @@ DRPrimitiveCompilationUnit >> addPrimitiveEntry: aDRPrimitiveObject [
 			ifTrue: [ aDRPrimitiveObject argumentCount ] }
 ]
 
-{ #category : #adding }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> addPrimitives [
 	"Iterate over the receiver's interpreter (assumed to contain primitive methods) and add them to compilationUnit"
 
@@ -56,17 +55,17 @@ DRPrimitiveCompilationUnit >> addPrimitives [
 		displayingProgress: [ : prim | 'Adding primitive: ' , prim asString ]
 ]
 
-{ #category : #'accessing - compiler' }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> addSpecialPrimitives [
 	"Private - Do nothing for now"
 ]
 
-{ #category : #adding }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> collectPrimitives: aCollection [ 
 	" Answer a <Collection> of selectors from aCollection containing CompiledMethod or primitive names "
 
 	^ aCollection 
-		reject: #isNumber
+		reject: [ : obj | obj isNumber or: [ obj isNil ] ]
 		thenCollect: [ : symOrCompiledMethod | 
 			symOrCompiledMethod isCompiledMethod 
 				ifTrue: [ symOrCompiledMethod selector ]
@@ -77,9 +76,6 @@ DRPrimitiveCompilationUnit >> collectPrimitives: aCollection [
 DRPrimitiveCompilationUnit >> compileAll [
 	"Write primitive methods in the receiver's JIT compiler class"
 
-	self primitives
-			do: [ : primitive | self compilePrimitive: primitive ]
-			displayingProgress: [ : primitive | 'Compiling primitive: ' , primitive asString ].
 	self compileInitializePrimitiveTable
 ]
 
@@ -107,7 +103,7 @@ DRPrimitiveCompilationUnit >> dispatchTableBuilder [
 	" Answer a <PCGMethodNode> representing the source code of the #initializePrimitiveTable compatible with Cogit "
 
 	^ dispatchTableBuilder
-		ifNil: [ dispatchTableBuilder := DRCogitDispatchTableBuilder primitiveTableMethodFrom: self ]
+		ifNil: [ dispatchTableBuilder := self dispatchTableBuilderClass primitiveTableMethodFrom: self ]
 ]
 
 { #category : #private }
@@ -117,6 +113,12 @@ DRPrimitiveCompilationUnit >> dispatchTableBuilder: aDRDispatchTableBuilder [
 	dispatchTableBuilder := aDRDispatchTableBuilder
 ]
 
+{ #category : #private }
+DRPrimitiveCompilationUnit >> dispatchTableBuilderClass [ 
+
+	^ DRCogitDispatchTableBuilder
+]
+
 { #category : #testing }
 DRPrimitiveCompilationUnit >> hasPrimitives [
 	"Answer <true> if the receiver already contains primitives"
@@ -124,7 +126,7 @@ DRPrimitiveCompilationUnit >> hasPrimitives [
 	^ self primitives notEmpty
 ]
 
-{ #category : #'accessing - compiler' }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> initPrimitiveTable [
 	"Answer a <Colllection> of <Array>. Each Array specifies an entry in the primitive table as expected by Cogit>>initializePrimitiveTable implementation"
 
@@ -144,10 +146,10 @@ DRPrimitiveCompilationUnit >> interpreter: aDRBasicInterpreter [
 	interpreter := aDRBasicInterpreter
 ]
 
-{ #category : #accessing }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> interpreterPrimitiveTable [
 
-	^ self compilerBuilder interpreterPrimitiveTable 
+	^ self targetClass basicPrimitiveTable 
 ]
 
 { #category : #testing }
@@ -156,7 +158,7 @@ DRPrimitiveCompilationUnit >> isValidPrimitiveName: aString [
 	^ aString isNumber not
 ]
 
-{ #category : #accessing }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> newPrimitive: aString [
 	" Answer a new primitive object with its metadata and CFG generated "
 
@@ -169,26 +171,12 @@ DRPrimitiveCompilationUnit >> newPrimitive: aString [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> primitiveMayCallback: aString [
 	"Answer <true> if primitive aString is marked as maycallback"
 	" #maycallback "
 
 	^ aString = #genNonImplementedPrimitive
-]
-
-{ #category : #accessing }
-DRPrimitiveCompilationUnit >> primitiveMethods [
-	" Answer a <Collection> of <CompiledMethod> including primitives "
-
-	^ primitiveMethods
-		ifNil: [ primitiveMethods := OrderedCollection new ]
-]
-
-{ #category : #accessing }
-DRPrimitiveCompilationUnit >> primitiveMethods: aCollection [
-
-	primitiveMethods := aCollection
 ]
 
 { #category : #'accessing - primitives' }
@@ -203,10 +191,17 @@ DRPrimitiveCompilationUnit >> primitiveNumberOf: aSelector [
 		ifFalse: [ primNumber ]
 ]
 
-{ #category : #accessing }
+{ #category : #'accessing - primitives' }
 DRPrimitiveCompilationUnit >> primitives [
 	"Answer a <Collection> of IR of primitive methods, instances of <DRPrimitiveControlFlowGraph>"
 
 	^ primitives
 		ifNil: [ primitives := OrderedCollection new ]
+]
+
+{ #category : #'accessing - primitives' }
+DRPrimitiveCompilationUnit >> primitives: aCollection [
+	"Set a <Collection> of primitive methods "
+
+	primitives := aCollection
 ]

--- a/Druid/DRStackCompilationUnit.class.st
+++ b/Druid/DRStackCompilationUnit.class.st
@@ -1,0 +1,81 @@
+Class {
+	#name : #DRStackCompilationUnit,
+	#superclass : #DRPrimitiveCompilationUnit,
+	#instVars : [
+		'primitiveIndex'
+	],
+	#category : #'Druid-CompilerBuilder'
+}
+
+{ #category : #'accessing - primitives' }
+DRStackCompilationUnit >> addPrimitiveEntries [
+	"As part of the build unit, add the receiver's primitives from its <Collection> of <DRPrimitiveObject>"
+
+	self addSpecialPrimitives.
+	self primitives do: [ :primitiveObject |
+		self addPrimitiveEntry: primitiveObject ]
+]
+
+{ #category : #'accessing - primitives' }
+DRStackCompilationUnit >> addPrimitiveEntry: aDRPrimitiveObject [
+	"Add a primitive entry compatible with the expected format from #initializePrimitiveTable implementation"
+
+	self initPrimitiveTable add: {
+		aDRPrimitiveObject primitiveNumber .
+		aDRPrimitiveObject sourceSelector }
+]
+
+{ #category : #adding }
+DRStackCompilationUnit >> addPrimitives: aCollection [ 
+
+	(self collectPrimitives: aCollection)
+		do: [ : prim | self addPrimitive: prim ]
+		displayingProgress: [ : prim | 'Adding primitive: ' , prim asString ]
+]
+
+{ #category : #'accessing - primitives' }
+DRStackCompilationUnit >> addSpecialPrimitives [
+	"Private - This is needed so to conform the primitive array 'specification'. Read AbstractInterpreter class>>tabble:from: side for details"
+
+	self initPrimitiveTable add: {
+		0 . 0 }
+]
+
+{ #category : #'accessing - compiler' }
+DRStackCompilationUnit >> compileInitializePrimitiveTable [
+	"Install the initialize primitive table method in the receiver's JIT compiler class"
+
+	self addPrimitiveEntries.
+	self dispatchTableBuilder
+		primitiveSpec: initPrimitiveTable;
+		installAllMethodsOn: self targetClass class
+]
+
+{ #category : #private }
+DRStackCompilationUnit >> dispatchTableBuilderClass [
+
+	^ DRStackInterpreterDispatchTableBuilder
+]
+
+{ #category : #initialization }
+DRStackCompilationUnit >> initialize [
+
+	super initialize.
+	primitiveIndex := 0
+]
+
+{ #category : #'accessing - primitives' }
+DRStackCompilationUnit >> newPrimitive: aString [
+	" Answer a new primitive object with its metadata and CFG generated "
+
+	^ DRPrimitiveObject new
+		primitiveNumber: self primitiveIndex;
+		sourceSelector: aString;
+		yourself
+]
+
+{ #category : #'accessing - primitives' }
+DRStackCompilationUnit >> primitiveIndex [
+
+	^ primitiveIndex :=  primitiveIndex + 1
+]

--- a/Druid/DRStackInterpreterDispatchTableBuilder.class.st
+++ b/Druid/DRStackInterpreterDispatchTableBuilder.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : #DRStackInterpreterDispatchTableBuilder,
+	#superclass : #DRAbstractDispatchTableBuilder,
+	#category : #'Druid-CompilerBuilder'
+}
+
+{ #category : #'accessing - building' }
+DRStackInterpreterDispatchTableBuilder >> arrayAccessorGlobalName [
+
+	^ #Array
+]
+
+{ #category : #'accessing - building' }
+DRStackInterpreterDispatchTableBuilder >> buildInitializePrimitiveTableAssignmentNode [
+	"Answer a <PCGMessageNode> with the primitive table initialization setter message send"
+
+	^ PCGMessageNode
+			receiver: (PCGMessageNode
+				receiver: #self asPCGNode
+				selector: #primitivesClass)
+			selector: #table:from:
+			arguments: { self buildPrimitiveTableVariableNode . #'self primitiveTableArray' asPCGArgument }
+]
+
+{ #category : #accessing }
+DRStackInterpreterDispatchTableBuilder >> buildPrimitiveTableInitialValueNode [
+
+	^ PCGMessageNode
+			receiver: #Array asPCGGlobal
+			selector: #new:
+			argument: (PCGMessageNode
+				receiver: self maxPrimitiveIndexGlobalName asPCGGlobal
+				selector: #+
+				arguments: { 1 asPCG })
+]
+
+{ #category : #'accessing - building' }
+DRStackInterpreterDispatchTableBuilder >> buildPrimitiveTableVariableNode [
+
+	^ #PrimitiveTable asPCGGlobal
+]
+
+{ #category : #initialization }
+DRStackInterpreterDispatchTableBuilder >> initPrimitiveTable [
+	"Answer a <Collection> with primitive table entries"
+
+	^ self primitiveSpec
+]
+
+{ #category : #'accessing - building' }
+DRStackInterpreterDispatchTableBuilder >> initPrimitiveTableSelector [ 
+
+	^ #basicPrimitiveTable
+]
+
+{ #category : #accessing }
+DRStackInterpreterDispatchTableBuilder >> maxPrimitiveIndexGlobalName [
+
+	^ #MaxPrimitiveIndex
+]

--- a/Druid/TDRMethodSelector.trait.st
+++ b/Druid/TDRMethodSelector.trait.st
@@ -1,0 +1,176 @@
+Trait {
+	#name : #TDRMethodSelector,
+	#instVars : [
+		'allowDuplicates',
+		'excludeObjectClass',
+		'scanSuperclasses',
+		'matchMethod',
+		'methods'
+	],
+	#category : #'Druid-CompilerBuilder'
+}
+
+{ #category : #querying }
+TDRMethodSelector >> addFromSelectorPattern: aString [
+	"Answer a <Collection> of selectors begining with aString"
+
+	aString ifEmpty: [ ^ Array empty ].
+	^ self methods addAll: (self scanSuperclasses
+		ifTrue: [ self allSelectorsMatching: aString ]
+		ifFalse: [ self selectorsMatching: aString ]).
+	
+]
+
+{ #category : #'accessing - query' }
+TDRMethodSelector >> allMethodsMatching: aString [
+	"Answer a <Collection> of <CompilerMethod> beginning with aString, looking up the pattern in the receiver's interpreter class methodDictionary, chase the superclass chain and try again until no method is found."
+
+	| lookupClass allSelectors |
+	lookupClass := self interpreterClass.
+	allSelectors := self collectorClass new.
+	[ self finishScanIn: lookupClass ] whileFalse: [
+		allSelectors addAll: (lookupClass methods select: [ : method |  method selector perform: self matchMethod with: aString ]).
+		lookupClass := lookupClass superclass ].
+	^ allSelectors
+]
+
+{ #category : #'accessing - query' }
+TDRMethodSelector >> allSelectorsMatching: aString [
+	"Answer a <Collection> of selectors begining with aString, looking up the pattern in the receiver's interpreter class methodDictionary, chase the superclass chain and try again until no method is found."
+
+	| lookupClass allSelectors |
+	lookupClass := self interpreterClass.
+	allSelectors := self collectorClass new.
+	[ lookupClass isNil ] whileFalse: [
+		allSelectors addAll: (lookupClass selectors select: [ :selector | selector perform: self matchMethod with: aString ]).
+		lookupClass := lookupClass superclass ].
+	^ allSelectors
+]
+
+{ #category : #accessing }
+TDRMethodSelector >> allowDuplicates [
+
+	^ allowDuplicates
+]
+
+{ #category : #accessing }
+TDRMethodSelector >> allowDuplicates: anObject [
+
+	allowDuplicates := anObject
+]
+
+{ #category : #accessing }
+TDRMethodSelector >> collectorClass [
+
+	^ self allowDuplicates
+		ifTrue: [ Bag ]
+		ifFalse: [ OrderedCollection ]
+]
+
+{ #category : #defaults }
+TDRMethodSelector >> defaultMatchMethod [
+
+	^ #beginsWith:
+]
+
+{ #category : #private }
+TDRMethodSelector >> excludeObjectClass [
+
+	^ excludeObjectClass
+		ifNil: [ excludeObjectClass := true ]
+]
+
+{ #category : #private }
+TDRMethodSelector >> finishScanIn: lookupClass [
+
+	^ lookupClass isNil or: [ self excludeObjectClass and: [ lookupClass = Object ] ]
+]
+
+{ #category : #initialization }
+TDRMethodSelector >> initialize [
+
+	super initialize.
+	scanSuperclasses := true.
+	allowDuplicates := true
+]
+
+{ #category : #'accessing - query' }
+TDRMethodSelector >> matchMethod [
+	"Answer a <Symbol> representing the selector used to compare against the primitive selectors"
+
+	^ matchMethod
+		ifNil: [ matchMethod := self defaultMatchMethod ]
+]
+
+{ #category : #'accessing - query' }
+TDRMethodSelector >> matchMethod: anObject [
+
+	matchMethod := anObject
+]
+
+{ #category : #querying }
+TDRMethodSelector >> methods [
+
+	^ methods
+		ifNil: [ methods := self collectorClass new ]
+]
+
+{ #category : #querying }
+TDRMethodSelector >> methods: aCollection [
+
+	methods := aCollection
+
+]
+
+{ #category : #querying }
+TDRMethodSelector >> methodsFromPattern: aString [
+	"Answer a <Collection> of selectors begining with aString"
+
+	aString ifEmpty: [ ^ Array empty ].
+	^ self methods addAll: (self scanSuperclasses
+		ifTrue: [ self allMethodsMatching: aString ]
+		ifFalse: [ self methodsMatching: aString ])
+]
+
+{ #category : #'accessing - query' }
+TDRMethodSelector >> methodsMatching: aString [
+	"Answer a <Collection> of selectors begining with aString"
+
+	^ self interpreterClass methods
+		select: [ : method | method selector perform: self matchMethod with: aString ]
+]
+
+{ #category : #accessing }
+TDRMethodSelector >> scanSuperclasses [
+
+	^ scanSuperclasses
+]
+
+{ #category : #accessing }
+TDRMethodSelector >> scanSuperclasses: aBoolean [
+	" Set <true> if receiver should scan superclasses for matching methods "
+
+	scanSuperclasses := aBoolean
+]
+
+{ #category : #'accessing - query' }
+TDRMethodSelector >> selectorsMatching: aString [
+	"Answer a <Collection> of selectors matching aString according to the receiver's match method"
+
+	^ self interpreterClass selectors
+		select: [ : selector | selector perform: self matchMethod with: aString ]
+]
+
+{ #category : #'accessing - query' }
+TDRMethodSelector >> useBeginsWith [
+	"Set the receiver to use regular expressions to match queries"
+
+	self matchMethod: #beginsWith:
+]
+
+{ #category : #'accessing - query' }
+TDRMethodSelector >> useRegEx [
+	"Set the receiver to use regular expressions to match queries"
+
+	self matchMethod: #matchesRegex:
+]


### PR DESCRIPTION
This PR includes changes to add an Interpreter Builder which can generate a narrowed version of an AbstractInterpreter (or StackInterpreter) with the same protocol as the Interpreter To Compiler for JIT compiler. The main difference is the Interpreter Builder does not compile any primitive, but generates methods to initialize its primitive table.
