### PR TITLE
Feat/compilingmethods

### DIFF
--- a/Druid-Tests/DRCompilationUnitTest.class.st
+++ b/Druid-Tests/DRCompilationUnitTest.class.st
@@ -22,9 +22,8 @@ DRCompilationUnitTest >> newEmptyCompilationUnit [
 	self flag: #TODO. "Duplicated from compilationUnitForTesting"
 
 	^ DRInterpreterCompilationUnit new
-		compilerBuilder: (DRInterpreterToCompiler fromInterpreterClass: DruidTestInterpreter);
-		targetClass: self compilerClassName;
-		yourself
+		  targetClass: self compilerClassName;
+		  yourself
 ]
 
 { #category : #'object access' }
@@ -55,7 +54,7 @@ DRCompilationUnitTest >> tearDown [
 { #category : #tests }
 DRCompilationUnitTest >> testManyPrimitivesCompilation [
 
-	| compilationUnit |
+	| compilationUnit compiler |
 	compilationUnit := self newEmptyCompilationUnit.
 
 	compilationUnit primitives: {
@@ -68,6 +67,7 @@ DRCompilationUnitTest >> testManyPrimitivesCompilation [
 			(DRJITPrimitiveObject new
 				 primitiveNumber: 2;
 				 argumentCount: -1;
+				 sourceMethod: self primitiveMethod;
 				 supported: false;
 				 yourself).
 
@@ -75,21 +75,26 @@ DRCompilationUnitTest >> testManyPrimitivesCompilation [
 				 primitiveNumber: 3;
 				 argumentCount: 3;
 				 supported: false;
+				 sourceMethod: self primitiveMethod;
 				 mayCallback: true;
-				 yourself) }.
+				 yourself) } asOrderedCollection.
 
-	compilationUnit compileAll.
+	compiler := (DRInterpreterToCompiler fromInterpreterClass: DruidTestInterpreter)
+		compilationUnit: compilationUnit;
+		yourself.
+	compilationUnit compileUsing: compiler.
+		
 
 	self assert: self compilerClass primitiveTableArray equals: {
 			#( 1 #gen_primitiveAdd 1 ).
 			#( 2 #genNonImplementedPrimitive -1 ).
-			#( 3 #genNonImplementedPrimitive 3 #maycallback ) }.
+			#( 3 #genNonImplementedPrimitive 3 #maycallback ) }
 ]
 
 { #category : #tests }
 DRCompilationUnitTest >> testMaycallbackPrimitiveCompilation [
 
-	| compilationUnit |
+	| compilationUnit compiler |
 	compilationUnit := self newEmptyCompilationUnit.
 
 	compilationUnit primitives: { (DRJITPrimitiveObject new
@@ -97,8 +102,11 @@ DRCompilationUnitTest >> testMaycallbackPrimitiveCompilation [
 			                    sourceMethod: self primitiveMethod;
 			                    argumentCount: 1;
 			                    mayCallback: true;
-			                    yourself) }.
-	compilationUnit compileAll.
+			                    yourself) } asOrderedCollection.
+
+	compiler := DRInterpreterToCompiler fromInterpreterClass: DruidTestInterpreter.
+	compiler compilationUnit: compilationUnit.
+	compilationUnit compileUsing: compiler.
 
 	self
 		assert: self compilerClass primitiveTableArray
@@ -108,34 +116,42 @@ DRCompilationUnitTest >> testMaycallbackPrimitiveCompilation [
 { #category : #tests }
 DRCompilationUnitTest >> testNotSupportedPrimitiveCompilation [
 
-	| compilationUnit |
+	| compilationUnit compiler |
 	compilationUnit := self newEmptyCompilationUnit.
 
 	compilationUnit primitives: { (DRJITPrimitiveObject new
 			 primitiveNumber: 7;
 			 argumentCount: -1;
+			 sourceMethod: self primitiveMethod;
 			 supported: false;
-			 yourself) }.
-	compilationUnit compileAll.
+			 yourself) } asOrderedCollection.
+
+	compiler := DRInterpreterToCompiler fromInterpreterClass: DruidTestInterpreter.
+	compiler compilationUnit: compilationUnit.
+	compilationUnit compileUsing: compiler.
 
 	self
 		assert: self compilerClass primitiveTableArray
-		equals: { #( 7 #genNonImplementedPrimitive -1 ) }.
+		equals: { #( 7 #genNonImplementedPrimitive
+		   -1 ) }.
 	self deny: (self compilerClass canUnderstand: #gen_fakePrimitive)
 ]
 
 { #category : #tests }
 DRCompilationUnitTest >> testPrimitiveCompilation [
 
-	| compilationUnit |
+	| compilationUnit compiler |
 	compilationUnit := self newEmptyCompilationUnit.
 
 	compilationUnit primitives: { (DRJITPrimitiveObject new
 			 primitiveNumber: 7;
 			 sourceMethod: self primitiveMethod;
 			 argumentCount: 1;
-			 yourself) }.
-	compilationUnit compileAll.
+			 yourself) } asOrderedCollection.
+
+	compiler := DRInterpreterToCompiler fromInterpreterClass: DruidTestInterpreter.
+	compiler compilationUnit: compilationUnit.
+	compilationUnit compileUsing: compiler.
 
 	self
 		assert: self compilerClass primitiveTableArray

--- a/Druid-Tests/DRInterpreterToCompilerTest.class.st
+++ b/Druid-Tests/DRInterpreterToCompilerTest.class.st
@@ -91,7 +91,7 @@ DRInterpreterToCompilerTest >> testErrorHandling [
 		selectPrimitives: [ : p | p selector = #primitiveDruidFail ];
 		buildAndCompileIn: self jitCompilerClassNameForTest.
 
-	self assert: interpreterToCompiler failedPrimitives notEmpty.
+	self assert: interpreterToCompiler errors notEmpty.
 ]
 
 { #category : #tests }

--- a/Druid/DRAbstractCompilerBuilder.class.st
+++ b/Druid/DRAbstractCompilerBuilder.class.st
@@ -19,8 +19,8 @@ Class {
 { #category : #'accessing - compiler' }
 DRAbstractCompilerBuilder >> compilationUnit [
 
-	^ compilationUnit
-		ifNil: [ 	compilationUnit := self compilationUnitClass fromCompilerBuilder: self ]
+	^ compilationUnit ifNil: [
+		  compilationUnit := self compilationUnitClass new ]
 ]
 
 { #category : #'accessing - compiler' }
@@ -50,6 +50,11 @@ DRAbstractCompilerBuilder >> environmentAt: aClass [
 	^ self class environment
 		at: className
 		ifAbsent: [ self newClassNamed: aClass superclass: realSuperclass ]
+]
+
+{ #category : #private }
+DRAbstractCompilerBuilder >> handleErrorDuring: aFullBlockClosure [ 
+	self shouldBeImplemented.
 ]
 
 { #category : #accessing }

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -31,3 +31,13 @@ DRBytecodeObject >> bytecodeSize: anObject [
 
 	bytecodeSize := anObject
 ]
+
+{ #category : #compiling }
+DRBytecodeObject >> compileUsing: aCompiler [
+
+	DRBytecodeCompilerCompiler new
+		sourceName: self sourceSelector;
+		interpreter: aCompiler newInterpreter;
+		compilerClass: aCompiler targetClass;
+		compile
+]

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -35,9 +35,12 @@ DRBytecodeObject >> bytecodeSize: anObject [
 { #category : #compiling }
 DRBytecodeObject >> compileUsing: aCompiler [
 
+	| interpreter |
+	interpreter := aCompiler newInterpreter.
+	interpreter currentBytecode: bytecodeNumber.
 	DRBytecodeCompilerCompiler new
 		sourceName: self sourceSelector;
-		interpreter: aCompiler newInterpreter;
+		interpreter: interpreter;
 		compilerClass: aCompiler targetClass;
 		compile
 ]

--- a/Druid/DRCompilationUnit.class.st
+++ b/Druid/DRCompilationUnit.class.st
@@ -10,45 +10,10 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'targetClass',
-		'targetSuperclass',
-		'compiler',
-		'compilerBuilder'
+		'targetSuperclass'
 	],
 	#category : #'Druid-CompilerBuilder'
 }
-
-{ #category : #'instance creation' }
-DRCompilationUnit class >> fromCompilerBuilder: aDRCompilerBuilder [
-
-	^  self new
-			compilerBuilder: aDRCompilerBuilder;
-			yourself
-]
-
-{ #category : #'accessing - compiler' }
-DRCompilationUnit >> compiler [
-
-	^ compiler
-
-]
-
-{ #category : #accessing }
-DRCompilationUnit >> compiler: aDRCompiler [ 
-
-	compiler := aDRCompiler
-]
-
-{ #category : #accessing }
-DRCompilationUnit >> compilerBuilder [
-
-	^ compilerBuilder
-]
-
-{ #category : #accessing }
-DRCompilationUnit >> compilerBuilder: anObject [
-
-	compilerBuilder := anObject
-]
 
 { #category : #accessing }
 DRCompilationUnit >> defaultTargetSuperclass [

--- a/Druid/DRInterpreterCompilationUnit.class.st
+++ b/Druid/DRInterpreterCompilationUnit.class.st
@@ -115,13 +115,14 @@ DRInterpreterCompilationUnit >> compileUsing: aCompiler [
 	"Install methods in the receiver's JIT compiler class"
 
 	| realTargetClass |
-	realTargetClass := self compilerBuilder environmentAt:
-		                   self targetClass.
+	realTargetClass := aCompiler environmentAt: self targetClass.
 	self addPrimitiveEntries.
 	self addBytecodeEntries.
-	
-	self primitives do: [ :e | e compileUsing: aCompiler ].
-	self bytecodes do: [ :e | e compileUsing: aCompiler ].
+
+	self primitives do: [ :e |
+		aCompiler handleErrorDuring: [ e compileUsing: aCompiler ] ].
+	self bytecodes do: [ :e |
+		aCompiler handleErrorDuring: [ e compileUsing: aCompiler ] ].
 
 	self dispatchTableGenerator installAllMethodsOn:
 		realTargetClass class

--- a/Druid/DRInterpreterCompilationUnit.class.st
+++ b/Druid/DRInterpreterCompilationUnit.class.st
@@ -98,19 +98,6 @@ DRInterpreterCompilationUnit >> collectPrimitives: aCollection [
 ]
 
 { #category : #'accessing - compiler' }
-DRInterpreterCompilationUnit >> compileAll [
-	"Install methods in the receiver's JIT compiler class"
-
-	| realTargetClass |
-	realTargetClass := self compilerBuilder environmentAt:
-		                   self targetClass.
-	self addPrimitiveEntries.
-	self addBytecodeEntries.
-	self dispatchTableGenerator installAllMethodsOn:
-		realTargetClass class
-]
-
-{ #category : #'accessing - compiler' }
 DRInterpreterCompilationUnit >> compilePrimitive: aDRPrimitiveObject [
 	"Compile a method in the receiver's JIT compiler class. aDRPrimitiveObject contains the specification needed to compile the JITed version of the method"
 
@@ -121,6 +108,23 @@ DRInterpreterCompilationUnit >> compilePrimitive: aDRPrimitiveObject [
 		sourceName: aDRPrimitiveObject sourceSelector;
 		primitiveCompilerName: aDRPrimitiveObject genSelector)
 			compile
+]
+
+{ #category : #'accessing - compiler' }
+DRInterpreterCompilationUnit >> compileUsing: aCompiler [
+	"Install methods in the receiver's JIT compiler class"
+
+	| realTargetClass |
+	realTargetClass := self compilerBuilder environmentAt:
+		                   self targetClass.
+	self addPrimitiveEntries.
+	self addBytecodeEntries.
+	
+	self primitives do: [ :e | e compileUsing: aCompiler ].
+	self bytecodes do: [ :e | e compileUsing: aCompiler ].
+
+	self dispatchTableGenerator installAllMethodsOn:
+		realTargetClass class
 ]
 
 { #category : #private }

--- a/Druid/DRInterpreterInstruction.class.st
+++ b/Druid/DRInterpreterInstruction.class.st
@@ -6,8 +6,7 @@ Class {
 	#name : #DRInterpreterInstruction,
 	#superclass : #Object,
 	#instVars : [
-		'sourceMethod',
-		'cfg'
+		'sourceMethod'
 	],
 	#category : #'Druid-CompilerBuilder'
 }

--- a/Druid/DRInterpreterInstruction.class.st
+++ b/Druid/DRInterpreterInstruction.class.st
@@ -12,16 +12,10 @@ Class {
 	#category : #'Druid-CompilerBuilder'
 }
 
-{ #category : #accessing }
-DRInterpreterInstruction >> cfg [
-
-	^ cfg
-]
-
-{ #category : #accessing }
-DRInterpreterInstruction >> cfg: aDRPrimitiveControlFlowGraph [ 
-
-	cfg := aDRPrimitiveControlFlowGraph
+{ #category : #compiling }
+DRInterpreterInstruction >> compileUsing: aCompiler [
+	
+	self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/Druid/DRInterpreterToCompiler.class.st
+++ b/Druid/DRInterpreterToCompiler.class.st
@@ -124,7 +124,7 @@ DRInterpreterToCompiler >> build [
 
 	self addPrimitives.
 	self addBytecodes.
-	^ self compilationUnit compileAll
+	^ self compilationUnit compileUsing: self
 ]
 
 { #category : #'accessing - model' }
@@ -197,12 +197,6 @@ DRInterpreterToCompiler >> collectPrimitives: aCollection [
 	^ validSelectors
 		  collect: [ :selector | interpreterClass lookupSelector: selector ]
 		  thenSelect: [ :method | self isSelectedPrimitive: method ]
-]
-
-{ #category : #'accessing - compiler' }
-DRInterpreterToCompiler >> compileAll [
-
-	self build compileAll
 ]
 
 { #category : #initialization }
@@ -344,7 +338,6 @@ DRInterpreterToCompiler >> newBytecode: aString [
 		bytecodeNumber: (self bytecodeNumberOf: aString);
 		bytecodeSize: (self bytecodeSizeOf: aString);
 		sourceMethod: (self interpreterClass lookupSelector: aString);
-		cfg: (self newBytecodeCompiler buildIR: aString);
 		yourself.
 	^ bytecodeObject
 	" (self isExtendedBytecode: aString) 
@@ -398,17 +391,17 @@ DRInterpreterToCompiler >> newNonImplementedPrimitive: interpreterPrimitiveMetho
 { #category : #'instance creation' }
 DRInterpreterToCompiler >> newPrimitive: primitiveMethod [
 	" Answer a new primitive object with its metadata and CFG generated "
+
 	| selector primCompiler |
-	
 	primCompiler := self newPrimitiveCompiler.
-  selector := primitiveMethod selector.
+	selector := primitiveMethod selector.
 	^ DRJITPrimitiveObject new
-		primitiveNumber: (self primitiveNumberOf: selector);
-		sourceMethod: primitiveMethod;
-		cfg: (primCompiler buildIR: selector);
-		argumentCount: (primCompiler numberOfArgumentsForMethod: primitiveMethod);
-		mayCallback: (self isMaycallbackPrimitive: primitiveMethod);
-		yourself
+		  primitiveNumber: (self primitiveNumberOf: selector);
+		  sourceMethod: primitiveMethod;
+		  argumentCount:
+			  (primCompiler numberOfArgumentsForMethod: primitiveMethod);
+		  mayCallback: (self isMaycallbackPrimitive: primitiveMethod);
+		  yourself
 ]
 
 { #category : #'accessing - compiler' }

--- a/Druid/DRInterpreterToCompiler.class.st
+++ b/Druid/DRInterpreterToCompiler.class.st
@@ -28,8 +28,7 @@ Class {
 		'failFirst',
 		'bytecodeCompiler',
 		'bytecodeSelector',
-		'failedPrimitives',
-		'failedBytecodes'
+		'errors'
 	],
 	#category : #'Druid-CompilerBuilder'
 }
@@ -104,7 +103,7 @@ DRInterpreterToCompiler >> addPrimitives [
 
 	(self collectPrimitives: self interpreterPrimitiveTable)
 		do: [ :prim | self addPrimitive: prim ]
-		displayingProgress: [ :prim | 'Adding primitive: ' , prim asString ].
+		displayingProgress: [ :prim | 'Adding primitive: ' , prim selector ].
 
 	self flag: #TOFIX.
 	self interpreterPrimitiveTable
@@ -206,11 +205,11 @@ DRInterpreterToCompiler >> doFailOnFirst [
 ]
 
 { #category : #adding }
-DRInterpreterToCompiler >> failedBytecodes [
+DRInterpreterToCompiler >> errors [
 
-	^ failedBytecodes
+	^ errors
 		ifNil: [
-			failedBytecodes :=
+			errors :=
 				PluggableDictionary new
 					equalBlock: [ :a :b | a class == b class ];
 					hashBlock: [ :a | a class identityHash ];
@@ -220,33 +219,29 @@ DRInterpreterToCompiler >> failedBytecodes [
 { #category : #adding }
 DRInterpreterToCompiler >> failedBytecodesAt: anException add: aString [
 
-	self failedBytecodes
+	self errors
 		at: anException
 		ifPresent: [ : fbs | fbs add: aString ]
-		ifAbsent: [ self failedBytecodes 
+		ifAbsent: [ self errors 
 			at: anException 
 			put: (OrderedCollection with: aString) ]
 ]
 
 { #category : #adding }
-DRInterpreterToCompiler >> failedPrimitives [
-
-	^ failedPrimitives
-		ifNil: [
-			failedPrimitives :=
-				PluggableDictionary new
-					equalBlock: [ :a :b | a class == b class ];
-					hashBlock: [ :a | a class identityHash ];
-					yourself 	]
-]
-
-{ #category : #adding }
 DRInterpreterToCompiler >> failedPrimitivesAt: anException add: aString [
 
-	self failedPrimitives
-		at: anException
-		ifPresent: [ : fps | fps add: aString ]
-		ifAbsent: [ self failedPrimitives at: anException put: (OrderedCollection with: aString)  ]
+	"Put all errors in a single place"
+	self failedBytecodesAt:  anException add: aString
+]
+
+{ #category : #private }
+DRInterpreterToCompiler >> handleErrorDuring: aFullBlockClosure [
+
+	aFullBlockClosure
+		on: Error
+		do: [ :ex |
+			failFirst ifTrue: [ ex pass ].
+			self failedBytecodesAt: ex add: ex asString ]
 ]
 
 { #category : #'accessing - object memory' }

--- a/Druid/DRJITPrimitiveObject.class.st
+++ b/Druid/DRJITPrimitiveObject.class.st
@@ -28,6 +28,19 @@ DRJITPrimitiveObject >> argumentCount: anObject [
 	argumentCount := anObject
 ]
 
+{ #category : #compiling }
+DRJITPrimitiveObject >> compileUsing: aCompiler [
+	
+	self supported ifFalse: [ ^ self ].
+	
+	DRPrimitiveCompilerCompiler new
+		primitiveName: self sourceSelector;
+		interpreter: aCompiler newInterpreter;
+		primitiveCompilerName: self genSelector;
+		compilerClass: aCompiler targetClass;
+		compile
+]
+
 { #category : #accessing }
 DRJITPrimitiveObject >> genSelector [
 	" Answer a <Symbol> specifying the JITed selector of the interpreter's counterpart (interpreter) method"


### PR DESCRIPTION
Now the following script builds a full class, methods and dispatch tables included

```smalltalk
accepted := #( 76 216 "92" ) collect: [ :n | StackInterpreter bytecodeTable at: n + 1 ].
(DRInterpreterToCompiler fromInterpreterClass: CogVMSimulatorLSB)
	doFailOnFirst;
	selectPrimitives: [ :e | 
		(StackInterpreter primitiveTable indexOf: e selector) between: 1 and: 10 ];
	selectBytecodes: [ :e | accepted includes: e selector ];
	targetClass: DruidJIT;
	targetSuperclass: StackToRegisterMappingCogit;
	build.
```