### PR TITLE
Suffix bytecode generators when required

### DIFF
--- a/Druid-Tests/DRInterpreterCompilationUnitTest.class.st
+++ b/Druid-Tests/DRInterpreterCompilationUnitTest.class.st
@@ -83,7 +83,23 @@ DRInterpreterCompilationUnitTest >> testBytecodeCompilation [
 
 	self
 		assert: self targetClass bytecodeTable
-		equals: { #( 1 0 15 #gen_PushReceiverVariableBytecode ) }.
+		equals: { 
+			#( 1 0 0 #gen_PushReceiverVariableBytecode0 ).
+			#( 1 1 1 #gen_PushReceiverVariableBytecode1 ).
+			#( 1 2 2 #gen_PushReceiverVariableBytecode2 ).
+			#( 1 3 3 #gen_PushReceiverVariableBytecode3 ).
+			#( 1 4 4 #gen_PushReceiverVariableBytecode4 ).
+			#( 1 5 5 #gen_PushReceiverVariableBytecode5 ).
+			#( 1 6 6 #gen_PushReceiverVariableBytecode6 ).
+			#( 1 7 7 #gen_PushReceiverVariableBytecode7 ).
+			#( 1 8 8 #gen_PushReceiverVariableBytecode8 ).
+			#( 1 9 9 #gen_PushReceiverVariableBytecode9 ).
+			#( 1 10 10 #gen_PushReceiverVariableBytecode10 ).
+			#( 1 11 11 #gen_PushReceiverVariableBytecode11 ).
+			#( 1 12 12 #gen_PushReceiverVariableBytecode12 ).
+			#( 1 13 13 #gen_PushReceiverVariableBytecode13 ).
+			#( 1 14 14 #gen_PushReceiverVariableBytecode14 ).
+			#( 1 15 15 #gen_PushReceiverVariableBytecode15 ). }.
 
 	self assert:
 		(self targetClass canUnderstand: #gen_PushReceiverVariableBytecode)
@@ -105,15 +121,30 @@ DRInterpreterCompilationUnitTest >> testManyBytecodesCompilation [
 			(DRBytecodeObject new
 				 bytecodeSize: 2;
 				 bytecodeNumberStart: 16;
-				 bytecodeNumberEnd: 30;
+				 bytecodeNumberEnd: 17;
 				 supported: false;
 				 yourself) } asOrderedCollection.
 
 	self compile: compilationUnit.
 
 	self assert: self targetClass bytecodeTable equals: {
-			#( 1 0 15 #gen_PushReceiverVariableBytecode ).
-			#( 2 16 30 #unknownBytecode ) }.
+			#( 1 0 0 #gen_PushReceiverVariableBytecode0 ).
+			#( 1 1 1 #gen_PushReceiverVariableBytecode1 ).
+			#( 1 2 2 #gen_PushReceiverVariableBytecode2 ).
+			#( 1 3 3 #gen_PushReceiverVariableBytecode3 ).
+			#( 1 4 4 #gen_PushReceiverVariableBytecode4 ).
+			#( 1 5 5 #gen_PushReceiverVariableBytecode5 ).
+			#( 1 6 6 #gen_PushReceiverVariableBytecode6 ).
+			#( 1 7 7 #gen_PushReceiverVariableBytecode7 ).
+			#( 1 8 8 #gen_PushReceiverVariableBytecode8 ).
+			#( 1 9 9 #gen_PushReceiverVariableBytecode9 ).
+			#( 1 10 10 #gen_PushReceiverVariableBytecode10 ).
+			#( 1 11 11 #gen_PushReceiverVariableBytecode11 ).
+			#( 1 12 12 #gen_PushReceiverVariableBytecode12 ).
+			#( 1 13 13 #gen_PushReceiverVariableBytecode13 ).
+			#( 1 14 14 #gen_PushReceiverVariableBytecode14 ).
+			#( 1 15 15 #gen_PushReceiverVariableBytecode15 ).
+			#( 2 16 17 #unknownBytecode ) }.
 
 	self assert:
 		(self targetClass canUnderstand: #gen_PushReceiverVariableBytecode)
@@ -189,7 +220,7 @@ DRInterpreterCompilationUnitTest >> testNotSupportedBytecodeCompilation [
 	compilationUnit bytecodes: { (DRBytecodeObject new
 			 bytecodeSize: 1;
 			 bytecodeNumberStart: 0;
-			 bytecodeNumberEnd: 15;
+			 bytecodeNumberEnd: 0;
 			 supported: false;
 			 yourself) } asOrderedCollection.
 
@@ -197,7 +228,7 @@ DRInterpreterCompilationUnitTest >> testNotSupportedBytecodeCompilation [
 
 	self
 		assert: self targetClass bytecodeTable
-		equals: { #( 1 0 15 #unknownBytecode ) }
+		equals: { #( 1 0 0 #unknownBytecode ) }
 ]
 
 { #category : #'tests - primitives' }

--- a/Druid-Tests/DRInterpreterCompilationUnitTest.class.st
+++ b/Druid-Tests/DRInterpreterCompilationUnitTest.class.st
@@ -101,8 +101,8 @@ DRInterpreterCompilationUnitTest >> testBytecodeCompilation [
 			#( 1 14 14 #gen_PushReceiverVariableBytecode14 ).
 			#( 1 15 15 #gen_PushReceiverVariableBytecode15 ). }.
 
-	self assert:
-		(self targetClass canUnderstand: #gen_PushReceiverVariableBytecode)
+	self targetClass bytecodeTable do: [ :e |
+		self assert: (self targetClass canUnderstand: e fourth) ]
 ]
 
 { #category : #'tests - bytecodes' }
@@ -146,8 +146,8 @@ DRInterpreterCompilationUnitTest >> testManyBytecodesCompilation [
 			#( 1 15 15 #gen_PushReceiverVariableBytecode15 ).
 			#( 2 16 17 #unknownBytecode ) }.
 
-	self assert:
-		(self targetClass canUnderstand: #gen_PushReceiverVariableBytecode)
+	self targetClass bytecodeTable do: [ :e |
+		self assert: (self targetClass canUnderstand: e fourth) ]
 ]
 
 { #category : #'tests - primitives' }
@@ -269,4 +269,27 @@ DRInterpreterCompilationUnitTest >> testPrimitiveCompilation [
 		equals: { #( 7 #gen_PrimitiveAdd 1 ) }.
 
 	self assert: (self targetClass canUnderstand: #gen_PrimitiveAdd)
+]
+
+{ #category : #'tests - bytecodes' }
+DRInterpreterCompilationUnitTest >> testSingleBytecodesCompilation [
+
+	| compilationUnit |
+	compilationUnit := self newEmptyCompilationUnit.
+
+	compilationUnit bytecodes: { (DRBytecodeObject new
+			 bytecodeSize: 1;
+			 bytecodeNumberStart: 0;
+			 bytecodeNumberEnd: 0;
+			 sourceMethod: self bytecodeMethod;
+			 yourself) } asOrderedCollection.
+
+	self compile: compilationUnit.
+
+	self
+		assert: self targetClass bytecodeTable
+		equals: { #( 1 0 0 #gen_PushReceiverVariableBytecode ) }.
+
+	self targetClass bytecodeTable do: [ :e |
+		self assert: (self targetClass canUnderstand: e fourth) ]
 ]

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -9,6 +9,29 @@ Class {
 	#category : #'Druid-CompilerBuilder'
 }
 
+{ #category : #compiling }
+DRBytecodeObject >> byteCodeEntries [
+
+	"We need to generate as many entries as there are bytecodes.
+	Each entry has a suffix.
+	If there is only one entry, do not add a suffix"	
+	(supported not or: [bytecodeNumberStart = bytecodeNumberEnd]) ifTrue: [ 
+		^ {{
+			self bytecodeSize.
+			self bytecodeNumberStart.
+			self bytecodeNumberEnd.
+			self genSelector }} ].
+	
+	^ (bytecodeNumberStart to: bytecodeNumberEnd) collect: [ :e |
+		| suffix |
+		suffix := e - bytecodeNumberStart.
+		{
+			self bytecodeSize.
+			e.
+			e.
+			self genSelector, suffix asString } ]
+]
+
 { #category : #accessing }
 DRBytecodeObject >> bytecodeNumber: anInteger [
 

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -80,13 +80,14 @@ DRBytecodeObject >> compileUnitUsing: aCompiler [
 
 	| interpreter |
 	interpreter := aCompiler newInterpreter.
-	interpreter currentBytecode: self bytecodeNumberStart.
-	DRBytecodeCompilerCompiler new
-		targetName: self genSelector;
-		sourceName: self sourceSelector;
-		interpreter: interpreter;
-		compilerClass: aCompiler targetClass;
-		compile
+	self bytecodeNumberStart to: self bytecodeNumberEnd do: [ :e |
+		interpreter currentBytecode: e.
+		DRBytecodeCompilerCompiler new
+			targetName: self genSelector , (e - self bytecodeNumberStart) asString;
+			sourceName: self sourceSelector;
+			interpreter: interpreter;
+			compilerClass: aCompiler targetClass;
+			compile ]
 ]
 
 { #category : #accessing }

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -80,10 +80,23 @@ DRBytecodeObject >> compileUnitUsing: aCompiler [
 
 	| interpreter |
 	interpreter := aCompiler newInterpreter.
+	"If this is a single bytecode range, compile the method without suffix"
+	self bytecodeNumberStart = self bytecodeNumberEnd ifTrue: [
+		interpreter currentBytecode: self bytecodeNumberStart.
+		^ DRBytecodeCompilerCompiler new
+			targetName: self genSelector;
+			sourceName: self sourceSelector;
+			interpreter: interpreter;
+			compilerClass: aCompiler targetClass;
+			compile ].
+	
+	"Otherwise iterate the bytecode and compile a variant per suffix"
 	self bytecodeNumberStart to: self bytecodeNumberEnd do: [ :e |
+		| suffix |
+		suffix := e - bytecodeNumberStart.
 		interpreter currentBytecode: e.
 		DRBytecodeCompilerCompiler new
-			targetName: self genSelector , (e - self bytecodeNumberStart) asString;
+			targetName: self genSelector , suffix asString;
 			sourceName: self sourceSelector;
 			interpreter: interpreter;
 			compilerClass: aCompiler targetClass;

--- a/Druid/DRCogitDispatchTableGenerator.class.st
+++ b/Druid/DRCogitDispatchTableGenerator.class.st
@@ -19,9 +19,13 @@ DRCogitDispatchTableGenerator >> arrayAccessorGlobalName [
 
 { #category : #'as yet unclassified' }
 DRCogitDispatchTableGenerator >> buildBytecodeTableMethodNode [
+	"Sort by bytecode number"
 
+	| sortedBytecodeTable |
+	sortedBytecodeTable := self bytecodeTable sorted: [ :e1 :e2 |
+		                       e1 second < e2 second ].
 	^ (PCGMethodNode selector: #bytecodeTable) bodyBlock: [ :body |
-		  body << self bytecodeTable asPCG returnIt ]
+		  body << sortedBytecodeTable asPCG returnIt ]
 ]
 
 { #category : #'accessing - bytecodes' }

--- a/Druid/DRInterpreterCompilationUnit.class.st
+++ b/Druid/DRInterpreterCompilationUnit.class.st
@@ -29,11 +29,7 @@ DRInterpreterCompilationUnit >> addBytecodeEntries [
 DRInterpreterCompilationUnit >> addBytecodeEntry: aDRBytecodeObject [
 	"Add a primitive entry compatible with the expected format from #initializePrimitiveTable implementation"
 
-	self bytecodeTable add: {
-			aDRBytecodeObject bytecodeSize.
-			aDRBytecodeObject bytecodeNumberStart.
-			aDRBytecodeObject bytecodeNumberEnd.
-			aDRBytecodeObject genSelector }
+	self bytecodeTable addAll: aDRBytecodeObject byteCodeEntries
 ]
 
 { #category : #'accessing - primitives' }


### PR DESCRIPTION
Expand bytecode entries if required.
Each entry should have a suffix.

Compile a method per suffixed variant