### PR TITLE
Fix/bytecodeselection

### DIFF
--- a/Druid-Tests/DRInterpreterCompilationUnitTest.class.st
+++ b/Druid-Tests/DRInterpreterCompilationUnitTest.class.st
@@ -83,7 +83,23 @@ DRInterpreterCompilationUnitTest >> testBytecodeCompilation [
 
 	self
 		assert: self targetClass bytecodeTable
-		equals: { #( 1 0 15 #gen_PushReceiverVariableBytecode ) }.
+		equals: { 
+			#( 1 0 0 #gen_PushReceiverVariableBytecode0 ).
+			#( 1 1 1 #gen_PushReceiverVariableBytecode1 ).
+			#( 1 2 2 #gen_PushReceiverVariableBytecode2 ).
+			#( 1 3 3 #gen_PushReceiverVariableBytecode3 ).
+			#( 1 4 4 #gen_PushReceiverVariableBytecode4 ).
+			#( 1 5 5 #gen_PushReceiverVariableBytecode5 ).
+			#( 1 6 6 #gen_PushReceiverVariableBytecode6 ).
+			#( 1 7 7 #gen_PushReceiverVariableBytecode7 ).
+			#( 1 8 8 #gen_PushReceiverVariableBytecode8 ).
+			#( 1 9 9 #gen_PushReceiverVariableBytecode9 ).
+			#( 1 10 10 #gen_PushReceiverVariableBytecode10 ).
+			#( 1 11 11 #gen_PushReceiverVariableBytecode11 ).
+			#( 1 12 12 #gen_PushReceiverVariableBytecode12 ).
+			#( 1 13 13 #gen_PushReceiverVariableBytecode13 ).
+			#( 1 14 14 #gen_PushReceiverVariableBytecode14 ).
+			#( 1 15 15 #gen_PushReceiverVariableBytecode15 ). }.
 
 	self assert:
 		(self targetClass canUnderstand: #gen_PushReceiverVariableBytecode)
@@ -105,15 +121,30 @@ DRInterpreterCompilationUnitTest >> testManyBytecodesCompilation [
 			(DRBytecodeObject new
 				 bytecodeSize: 2;
 				 bytecodeNumberStart: 16;
-				 bytecodeNumberEnd: 30;
+				 bytecodeNumberEnd: 17;
 				 supported: false;
 				 yourself) } asOrderedCollection.
 
 	self compile: compilationUnit.
 
 	self assert: self targetClass bytecodeTable equals: {
-			#( 1 0 15 #gen_PushReceiverVariableBytecode ).
-			#( 2 16 30 #unknownBytecode ) }.
+			#( 1 0 0 #gen_PushReceiverVariableBytecode0 ).
+			#( 1 1 1 #gen_PushReceiverVariableBytecode1 ).
+			#( 1 2 2 #gen_PushReceiverVariableBytecode2 ).
+			#( 1 3 3 #gen_PushReceiverVariableBytecode3 ).
+			#( 1 4 4 #gen_PushReceiverVariableBytecode4 ).
+			#( 1 5 5 #gen_PushReceiverVariableBytecode5 ).
+			#( 1 6 6 #gen_PushReceiverVariableBytecode6 ).
+			#( 1 7 7 #gen_PushReceiverVariableBytecode7 ).
+			#( 1 8 8 #gen_PushReceiverVariableBytecode8 ).
+			#( 1 9 9 #gen_PushReceiverVariableBytecode9 ).
+			#( 1 10 10 #gen_PushReceiverVariableBytecode10 ).
+			#( 1 11 11 #gen_PushReceiverVariableBytecode11 ).
+			#( 1 12 12 #gen_PushReceiverVariableBytecode12 ).
+			#( 1 13 13 #gen_PushReceiverVariableBytecode13 ).
+			#( 1 14 14 #gen_PushReceiverVariableBytecode14 ).
+			#( 1 15 15 #gen_PushReceiverVariableBytecode15 ).
+			#( 2 16 17 #unknownBytecode ) }.
 
 	self assert:
 		(self targetClass canUnderstand: #gen_PushReceiverVariableBytecode)
@@ -189,7 +220,7 @@ DRInterpreterCompilationUnitTest >> testNotSupportedBytecodeCompilation [
 	compilationUnit bytecodes: { (DRBytecodeObject new
 			 bytecodeSize: 1;
 			 bytecodeNumberStart: 0;
-			 bytecodeNumberEnd: 15;
+			 bytecodeNumberEnd: 0;
 			 supported: false;
 			 yourself) } asOrderedCollection.
 
@@ -197,7 +228,7 @@ DRInterpreterCompilationUnitTest >> testNotSupportedBytecodeCompilation [
 
 	self
 		assert: self targetClass bytecodeTable
-		equals: { #( 1 0 15 #unknownBytecode ) }
+		equals: { #( 1 0 0 #unknownBytecode ) }
 ]
 
 { #category : #'tests - primitives' }

--- a/Druid-Tests/DRInterpreterCompilationUnitTest.class.st
+++ b/Druid-Tests/DRInterpreterCompilationUnitTest.class.st
@@ -101,8 +101,8 @@ DRInterpreterCompilationUnitTest >> testBytecodeCompilation [
 			#( 1 14 14 #gen_PushReceiverVariableBytecode14 ).
 			#( 1 15 15 #gen_PushReceiverVariableBytecode15 ). }.
 
-	self assert:
-		(self targetClass canUnderstand: #gen_PushReceiverVariableBytecode)
+	self targetClass bytecodeTable do: [ :e |
+		self assert: (self targetClass canUnderstand: e fourth) ]
 ]
 
 { #category : #'tests - bytecodes' }
@@ -146,8 +146,8 @@ DRInterpreterCompilationUnitTest >> testManyBytecodesCompilation [
 			#( 1 15 15 #gen_PushReceiverVariableBytecode15 ).
 			#( 2 16 17 #unknownBytecode ) }.
 
-	self assert:
-		(self targetClass canUnderstand: #gen_PushReceiverVariableBytecode)
+	self targetClass bytecodeTable do: [ :e |
+		self assert: (self targetClass canUnderstand: e fourth) ]
 ]
 
 { #category : #'tests - primitives' }
@@ -269,4 +269,27 @@ DRInterpreterCompilationUnitTest >> testPrimitiveCompilation [
 		equals: { #( 7 #gen_PrimitiveAdd 1 ) }.
 
 	self assert: (self targetClass canUnderstand: #gen_PrimitiveAdd)
+]
+
+{ #category : #'tests - bytecodes' }
+DRInterpreterCompilationUnitTest >> testSingleBytecodesCompilation [
+
+	| compilationUnit |
+	compilationUnit := self newEmptyCompilationUnit.
+
+	compilationUnit bytecodes: { (DRBytecodeObject new
+			 bytecodeSize: 1;
+			 bytecodeNumberStart: 0;
+			 bytecodeNumberEnd: 0;
+			 sourceMethod: self bytecodeMethod;
+			 yourself) } asOrderedCollection.
+
+	self compile: compilationUnit.
+
+	self
+		assert: self targetClass bytecodeTable
+		equals: { #( 1 0 0 #gen_PushReceiverVariableBytecode ) }.
+
+	self targetClass bytecodeTable do: [ :e |
+		self assert: (self targetClass canUnderstand: e fourth) ]
 ]

--- a/Druid-Tests/DRInterpreterToCompilerTest.class.st
+++ b/Druid-Tests/DRInterpreterToCompilerTest.class.st
@@ -106,7 +106,7 @@ DRInterpreterToCompilerTest >> testSelectBytecodeCompilationUnits [
 
 	| supportedBytecode unknownBytecodes currentBytecodeNumber |
 	interpreterToCompiler
-		selectBytecodes: [ :cm | cm selector = #pushReceiverVariableBytecode ];
+		selectBytecodes: [ :e | e sourceSelector = #pushReceiverVariableBytecode ];
 		build.
 
 	supportedBytecode := interpreterToCompiler bytecodes first.
@@ -118,7 +118,7 @@ DRInterpreterToCompilerTest >> testSelectBytecodeCompilationUnits [
 		equals: 0.
 	self
 		assert: supportedBytecode bytecodeNumberEnd
-		equals: 15.
+		equals: 0.
 	self
 		assert: supportedBytecode sourceSelector
 		equals: #pushReceiverVariableBytecode.
@@ -127,7 +127,7 @@ DRInterpreterToCompilerTest >> testSelectBytecodeCompilationUnits [
 		equals: #gen_PushReceiverVariableBytecode.
 	self assert: supportedBytecode supported.
 
-	unknownBytecodes := interpreterToCompiler bytecodes allButFirst.
+	unknownBytecodes := interpreterToCompiler bytecodes allButFirst: 16.
 	self assert: unknownBytecodes isNotEmpty.
 	
 	"Continue from previous bytecode"
@@ -162,7 +162,7 @@ DRInterpreterToCompilerTest >> testSelectSingleBytecodeNumberCompilationUnits [
 
 	| supportedBytecode |
 	interpreterToCompiler
-		selectBytecodes: [ :cm | cm selector = #pushConstantTrueBytecode ];
+		selectBytecodes: [ :e | e sourceSelector = #pushConstantTrueBytecode ];
 		build.
 
 	supportedBytecode := interpreterToCompiler bytecodes first.

--- a/Druid-Tests/DRInterpreterToCompilerTest.class.st
+++ b/Druid-Tests/DRInterpreterToCompilerTest.class.st
@@ -106,35 +106,30 @@ DRInterpreterToCompilerTest >> testSelectBytecodeCompilationUnits [
 
 	| supportedBytecode unknownBytecodes currentBytecodeNumber |
 	interpreterToCompiler
-		selectBytecodes: [ :e | e sourceSelector = #pushReceiverVariableBytecode ];
+		selectBytecodes: [ :e |
+			e sourceSelector = #pushReceiverVariableBytecode ];
 		build.
 
-	supportedBytecode := interpreterToCompiler bytecodes first.
-	self
-		assert: supportedBytecode bytecodeSize
-		equals: 1.
-	self
-		assert: supportedBytecode bytecodeNumberStart
-		equals: 0.
-	self
-		assert: supportedBytecode bytecodeNumberEnd
-		equals: 0.
-	self
-		assert: supportedBytecode sourceSelector
-		equals: #pushReceiverVariableBytecode.
-	self
-		assert: supportedBytecode genSelector
-		equals: #gen_PushReceiverVariableBytecode.
-	self assert: supportedBytecode supported.
+	supportedBytecode := interpreterToCompiler bytecodes first: 16.
+	supportedBytecode withIndexDo: [ :e :i |
+		self assert: e bytecodeSize equals: 1.
+		self assert: e bytecodeNumberStart equals: i - 1.
+		self assert: e bytecodeNumberEnd equals: i - 1.
+		self assert: e sourceSelector equals: #pushReceiverVariableBytecode.
+		self
+			assert: e genSelector
+			equals: #gen_pushReceiverVariableBytecode , (i - 1) asString.
+		self assert: e supported ].
 
 	unknownBytecodes := interpreterToCompiler bytecodes allButFirst: 16.
 	self assert: unknownBytecodes isNotEmpty.
-	
+
 	"Continue from previous bytecode"
-	currentBytecodeNumber := supportedBytecode bytecodeNumberEnd.
+	currentBytecodeNumber := 15.
 	unknownBytecodes doWithIndex: [ :bytecodeUnit :index |
 		self assert: bytecodeUnit bytecodeSize equals: index.
-		self assert: bytecodeUnit bytecodeNumberStart > currentBytecodeNumber.
+		self assert:
+			bytecodeUnit bytecodeNumberStart > currentBytecodeNumber.
 		currentBytecodeNumber := bytecodeUnit bytecodeNumberStart.
 		self assert: bytecodeUnit bytecodeNumberEnd > currentBytecodeNumber.
 		currentBytecodeNumber := bytecodeUnit bytecodeNumberEnd.
@@ -180,7 +175,7 @@ DRInterpreterToCompilerTest >> testSelectSingleBytecodeNumberCompilationUnits [
 		equals: #pushConstantTrueBytecode.
 	self
 		assert: supportedBytecode genSelector
-		equals: #gen_PushConstantTrueBytecode.
+		equals: #gen_pushConstantTrueBytecode.
 	self assert: supportedBytecode supported.
 
 ]

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -9,6 +9,29 @@ Class {
 	#category : #'Druid-CompilerBuilder'
 }
 
+{ #category : #compiling }
+DRBytecodeObject >> byteCodeEntries [
+
+	"We need to generate as many entries as there are bytecodes.
+	Each entry has a suffix.
+	If there is only one entry, do not add a suffix"	
+	(supported not or: [bytecodeNumberStart = bytecodeNumberEnd]) ifTrue: [ 
+		^ {{
+			self bytecodeSize.
+			self bytecodeNumberStart.
+			self bytecodeNumberEnd.
+			self genSelector }} ].
+	
+	^ (bytecodeNumberStart to: bytecodeNumberEnd) collect: [ :e |
+		| suffix |
+		suffix := e - bytecodeNumberStart.
+		{
+			self bytecodeSize.
+			e.
+			e.
+			self genSelector, suffix asString } ]
+]
+
 { #category : #accessing }
 DRBytecodeObject >> bytecodeNumber: anInteger [
 

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -3,8 +3,8 @@ Class {
 	#superclass : #DRInterpreterInstruction,
 	#instVars : [
 		'bytecodeSize',
-		'bytecodeNumberStart',
-		'bytecodeNumberEnd'
+		'bytecodeNumberEnd',
+		'bytecodeNumber'
 	],
 	#category : #'Druid-CompilerBuilder'
 }
@@ -15,16 +15,16 @@ DRBytecodeObject >> byteCodeEntries [
 	"We need to generate as many entries as there are bytecodes.
 	Each entry has a suffix.
 	If there is only one entry, do not add a suffix"	
-	(supported not or: [bytecodeNumberStart = bytecodeNumberEnd]) ifTrue: [ 
+	(supported not or: [bytecodeNumber = bytecodeNumberEnd]) ifTrue: [ 
 		^ {{
 			self bytecodeSize.
 			self bytecodeNumberStart.
 			self bytecodeNumberEnd.
 			self genSelector }} ].
 	
-	^ (bytecodeNumberStart to: bytecodeNumberEnd) collect: [ :e |
+	^ (bytecodeNumber to: bytecodeNumberEnd) collect: [ :e |
 		| suffix |
-		suffix := e - bytecodeNumberStart.
+		suffix := e - bytecodeNumber.
 		{
 			self bytecodeSize.
 			e.
@@ -35,7 +35,7 @@ DRBytecodeObject >> byteCodeEntries [
 { #category : #accessing }
 DRBytecodeObject >> bytecodeNumber: anInteger [
 
-	bytecodeNumberStart := anInteger.
+	bytecodeNumber := anInteger.
 	bytecodeNumberEnd := anInteger
 ]
 
@@ -54,13 +54,13 @@ DRBytecodeObject >> bytecodeNumberEnd: anObject [
 { #category : #accessing }
 DRBytecodeObject >> bytecodeNumberStart [
 
-	^ bytecodeNumberStart
+	^ bytecodeNumber
 ]
 
 { #category : #accessing }
 DRBytecodeObject >> bytecodeNumberStart: anObject [
 
-	bytecodeNumberStart := anObject
+	bytecodeNumber := anObject
 ]
 
 { #category : #accessing }
@@ -93,7 +93,7 @@ DRBytecodeObject >> compileUnitUsing: aCompiler [
 	"Otherwise iterate the bytecode and compile a variant per suffix"
 	self bytecodeNumberStart to: self bytecodeNumberEnd do: [ :e |
 		| suffix |
-		suffix := e - bytecodeNumberStart.
+		suffix := e - bytecodeNumber.
 		interpreter currentBytecode: e.
 		DRBytecodeCompilerCompiler new
 			targetName: self genSelector , suffix asString;

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -80,13 +80,14 @@ DRBytecodeObject >> compileUnitUsing: aCompiler [
 
 	| interpreter |
 	interpreter := aCompiler newInterpreter.
-	interpreter currentBytecode: self bytecodeNumberStart.
-	DRBytecodeCompilerCompiler new
-		targetName: self genSelector;
-		sourceName: self sourceSelector;
-		interpreter: interpreter;
-		compilerClass: aCompiler targetClass;
-		compile
+	self bytecodeNumberStart to: self bytecodeNumberEnd do: [ :e |
+		interpreter currentBytecode: e.
+		DRBytecodeCompilerCompiler new
+			targetName: self genSelector , (e - self bytecodeNumberStart) asString;
+			sourceName: self sourceSelector;
+			interpreter: interpreter;
+			compilerClass: aCompiler targetClass;
+			compile ]
 ]
 
 { #category : #accessing }

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -80,10 +80,23 @@ DRBytecodeObject >> compileUnitUsing: aCompiler [
 
 	| interpreter |
 	interpreter := aCompiler newInterpreter.
+	"If this is a single bytecode range, compile the method without suffix"
+	self bytecodeNumberStart = self bytecodeNumberEnd ifTrue: [
+		interpreter currentBytecode: self bytecodeNumberStart.
+		^ DRBytecodeCompilerCompiler new
+			targetName: self genSelector;
+			sourceName: self sourceSelector;
+			interpreter: interpreter;
+			compilerClass: aCompiler targetClass;
+			compile ].
+	
+	"Otherwise iterate the bytecode and compile a variant per suffix"
 	self bytecodeNumberStart to: self bytecodeNumberEnd do: [ :e |
+		| suffix |
+		suffix := e - bytecodeNumberStart.
 		interpreter currentBytecode: e.
 		DRBytecodeCompilerCompiler new
-			targetName: self genSelector , (e - self bytecodeNumberStart) asString;
+			targetName: self genSelector , suffix asString;
 			sourceName: self sourceSelector;
 			interpreter: interpreter;
 			compilerClass: aCompiler targetClass;

--- a/Druid/DRBytecodeObject.class.st
+++ b/Druid/DRBytecodeObject.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'bytecodeSize',
 		'bytecodeNumberEnd',
-		'bytecodeNumber'
+		'bytecodeNumber',
+		'targetSelector'
 	],
 	#category : #'Druid-CompilerBuilder'
 }
@@ -12,24 +13,14 @@ Class {
 { #category : #compiling }
 DRBytecodeObject >> byteCodeEntries [
 
-	"We need to generate as many entries as there are bytecodes.
-	Each entry has a suffix.
-	If there is only one entry, do not add a suffix"	
-	(supported not or: [bytecodeNumber = bytecodeNumberEnd]) ifTrue: [ 
-		^ {{
-			self bytecodeSize.
-			self bytecodeNumberStart.
-			self bytecodeNumberEnd.
-			self genSelector }} ].
-	
 	^ (bytecodeNumber to: bytecodeNumberEnd) collect: [ :e |
-		| suffix |
-		suffix := e - bytecodeNumber.
-		{
-			self bytecodeSize.
-			e.
-			e.
-			self genSelector, suffix asString } ]
+		  | suffix |
+		  suffix := e - bytecodeNumber.
+		  {
+			  self bytecodeSize.
+			  e.
+			  e.
+			  self genSelector } ]
 ]
 
 { #category : #accessing }
@@ -80,23 +71,10 @@ DRBytecodeObject >> compileUnitUsing: aCompiler [
 
 	| interpreter |
 	interpreter := aCompiler newInterpreter.
-	"If this is a single bytecode range, compile the method without suffix"
-	self bytecodeNumberStart = self bytecodeNumberEnd ifTrue: [
-		interpreter currentBytecode: self bytecodeNumberStart.
-		^ DRBytecodeCompilerCompiler new
-			targetName: self genSelector;
-			sourceName: self sourceSelector;
-			interpreter: interpreter;
-			compilerClass: aCompiler targetClass;
-			compile ].
-	
-	"Otherwise iterate the bytecode and compile a variant per suffix"
 	self bytecodeNumberStart to: self bytecodeNumberEnd do: [ :e |
-		| suffix |
-		suffix := e - bytecodeNumber.
 		interpreter currentBytecode: e.
 		DRBytecodeCompilerCompiler new
-			targetName: self genSelector , suffix asString;
+			targetName: self genSelector;
 			sourceName: self sourceSelector;
 			interpreter: interpreter;
 			compilerClass: aCompiler targetClass;
@@ -122,4 +100,16 @@ DRBytecodeObject >> printOn: aStream [
 		<< self bytecodeNumberEnd asString;
 		space;
 		<< self genSelector
+]
+
+{ #category : #accessing }
+DRBytecodeObject >> targetSelector [
+
+	^ targetSelector
+]
+
+{ #category : #accessing }
+DRBytecodeObject >> targetSelector: anObject [
+
+	targetSelector := anObject
 ]

--- a/Druid/DRCogitDispatchTableGenerator.class.st
+++ b/Druid/DRCogitDispatchTableGenerator.class.st
@@ -19,9 +19,13 @@ DRCogitDispatchTableGenerator >> arrayAccessorGlobalName [
 
 { #category : #'as yet unclassified' }
 DRCogitDispatchTableGenerator >> buildBytecodeTableMethodNode [
+	"Sort by bytecode number"
 
+	| sortedBytecodeTable |
+	sortedBytecodeTable := self bytecodeTable sorted: [ :e1 :e2 |
+		                       e1 second < e2 second ].
 	^ (PCGMethodNode selector: #bytecodeTable) bodyBlock: [ :body |
-		  body << self bytecodeTable asPCG returnIt ]
+		  body << sortedBytecodeTable asPCG returnIt ]
 ]
 
 { #category : #'accessing - bytecodes' }

--- a/Druid/DRInterpreterCompilationUnit.class.st
+++ b/Druid/DRInterpreterCompilationUnit.class.st
@@ -29,11 +29,7 @@ DRInterpreterCompilationUnit >> addBytecodeEntries [
 DRInterpreterCompilationUnit >> addBytecodeEntry: aDRBytecodeObject [
 	"Add a primitive entry compatible with the expected format from #initializePrimitiveTable implementation"
 
-	self bytecodeTable add: {
-			aDRBytecodeObject bytecodeSize.
-			aDRBytecodeObject bytecodeNumberStart.
-			aDRBytecodeObject bytecodeNumberEnd.
-			aDRBytecodeObject genSelector }
+	self bytecodeTable addAll: aDRBytecodeObject byteCodeEntries
 ]
 
 { #category : #'accessing - primitives' }

--- a/Druid/DRInterpreterInstruction.class.st
+++ b/Druid/DRInterpreterInstruction.class.st
@@ -32,7 +32,7 @@ DRInterpreterInstruction >> genSelector [
 
 	supported ifFalse: [ ^ self notSupportedSelector ].
 
-	^ #gen_ , self sourceSelector capitalized
+	^ self targetSelector
 ]
 
 { #category : #testing }
@@ -45,6 +45,13 @@ DRInterpreterInstruction >> hasPragmaNamed: aString [
 DRInterpreterInstruction >> initialize [
 
 	supported := true
+]
+
+{ #category : #accessing }
+DRInterpreterInstruction >> notSupportedSelector [
+	"Should return the selector used when this instruction is not supported in the compiler"
+
+	self subclassResponsibility
 ]
 
 { #category : #accessing }
@@ -75,4 +82,11 @@ DRInterpreterInstruction >> supported [
 DRInterpreterInstruction >> supported: aBoolean [
 
 	supported := aBoolean
+]
+
+{ #category : #accessing }
+DRInterpreterInstruction >> targetSelector [
+	"Answer a <Symbol> specifying the JITed selector of the interpreter's counterpart (compiler) method"
+
+	^ #gen_ , self sourceSelector capitalized
 ]

--- a/Druid/DRInterpreterToCompiler.class.st
+++ b/Druid/DRInterpreterToCompiler.class.st
@@ -392,22 +392,6 @@ DRInterpreterToCompiler >> isValidPrimitiveName: aString [
 	^ aString isNumber not
 ]
 
-{ #category : #adding }
-DRInterpreterToCompiler >> newBytecode: bytecodeMethod [
-
-	| bytecodeGroup |
-	bytecodeGroup := self bytecodeGroupOf: bytecodeMethod selector.
-
-	^ DRBytecodeObject new
-		  bytecodeSize: bytecodeGroup first;
-		  bytecodeNumberStart: bytecodeGroup second;
-		  bytecodeNumberEnd: (bytecodeGroup third isNumber
-				   ifTrue: [ bytecodeGroup third ]
-				   ifFalse: [ bytecodeGroup second ]);
-		  sourceMethod: bytecodeMethod;
-		  yourself
-]
-
 { #category : #'accessing - compiler' }
 DRInterpreterToCompiler >> newBytecodeCompiler [
 
@@ -419,7 +403,7 @@ DRInterpreterToCompiler >> newBytecodeCompiler [
 { #category : #adding }
 DRInterpreterToCompiler >> newBytecodes: bytecodeMethod [
 
-	| bytecodeGroup start end |
+	| bytecodeGroup start end needsSuffix |
 	bytecodeGroup := self bytecodeGroupOf: bytecodeMethod selector.
 
 	start := bytecodeGroup second.
@@ -427,19 +411,16 @@ DRInterpreterToCompiler >> newBytecodes: bytecodeMethod [
 		       ifTrue: [ bytecodeGroup third ]
 		       ifFalse: [ bytecodeGroup second ].
 
-	start = end ifTrue: [
-		^ { (DRBytecodeObject new
-			   bytecodeSize: bytecodeGroup first;
-			   bytecodeNumberStart: start;
-			   bytecodeNumberEnd: end;
-			   sourceMethod: bytecodeMethod;
-			   yourself) } ].
-
-	^ (start to: end) collect: [ :e |
+	needsSuffix := start ~= end.
+	^ (start to: end) collect: [ :e | | suffix |
+		  suffix := needsSuffix
+			            ifTrue: [ e - start ]
+			            ifFalse: [ '' ].
 		  DRBytecodeObject new
 			  bytecodeSize: bytecodeGroup first;
 			  bytecodeNumberStart: e;
 			  bytecodeNumberEnd: e;
+			  targetSelector: 'gen_' , bytecodeMethod selector , suffix asString;
 			  sourceMethod: bytecodeMethod;
 			  yourself ]
 ]

--- a/Druid/DRInterpreterToCompiler.class.st
+++ b/Druid/DRInterpreterToCompiler.class.st
@@ -61,31 +61,25 @@ DRInterpreterToCompiler class >> generateDruidJITModel [
 	(self fromInterpreterClass: CogVMSimulatorLSB)
 		doFailOnFirst;
 		selectPrimitives: [ :e | primitives includes: e selector ];
-		selectBytecodes: [ :e | bytecodes includes: e selector ];
+		selectBytecodes: [ :e | bytecodes includes: e sourceSelector ];
 		targetClass: DruidJIT;
 		targetSuperclass: StackToRegisterMappingCogit;
 		build
 ]
 
 { #category : #'accessing - bytecodes' }
-DRInterpreterToCompiler >> addBytecode: bytecodeMethod [
-
-	[ self bytecodes add: (self newBytecode: bytecodeMethod) ]
-	on: Error
-	do: [ : ex | 
-		failFirst ifTrue: [ ex pass  ].
-		self 
-			failedBytecodesAt: ex
-			add: bytecodeMethod ].
-
-]
-
-{ #category : #'accessing - bytecodes' }
 DRInterpreterToCompiler >> addBytecodes [
 	"Iterate over the receiver's interpreter (assumed to contain primitive methods) and add them to compilationUnit"
 
-	(self collectBytecodes: self interpreterBytecodeTable) do: [ :prim |
-		self addBytecode: prim ].
+	| bytecodes |
+	bytecodes := (self interpreterBytecodeTable
+		             reject: [ :e | e isNil ])
+		flatCollect: [ :e |
+		             self newBytecodes: (interpreterClass lookupSelector: e) ].
+
+	bytecodes
+		select: [ :e | self isSelectedBytecode: e ]
+		thenDo: [ :e | self bytecodes add: e ].
 
 	self fillBytecodesTableHoles
 ]
@@ -420,6 +414,34 @@ DRInterpreterToCompiler >> newBytecodeCompiler [
 	^ (DRBytecodeCompilerCompiler forInterpreter: self newInterpreter)
 		compilerClass: self targetClass;
 		yourself
+]
+
+{ #category : #adding }
+DRInterpreterToCompiler >> newBytecodes: bytecodeMethod [
+
+	| bytecodeGroup start end |
+	bytecodeGroup := self bytecodeGroupOf: bytecodeMethod selector.
+
+	start := bytecodeGroup second.
+	end := bytecodeGroup third isNumber
+		       ifTrue: [ bytecodeGroup third ]
+		       ifFalse: [ bytecodeGroup second ].
+
+	start = end ifTrue: [
+		^ { (DRBytecodeObject new
+			   bytecodeSize: bytecodeGroup first;
+			   bytecodeNumberStart: start;
+			   bytecodeNumberEnd: end;
+			   sourceMethod: bytecodeMethod;
+			   yourself) } ].
+
+	^ (start to: end) collect: [ :e |
+		  DRBytecodeObject new
+			  bytecodeSize: bytecodeGroup first;
+			  bytecodeNumberStart: e;
+			  bytecodeNumberEnd: e;
+			  sourceMethod: bytecodeMethod;
+			  yourself ]
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
Depends on #45 

Make bytecode selection happen on the bytecode object, not on the compiled method.
This allows bytecode selection grab more information than just the source method's metadata.
For example, it has now where it is installed in the table, and it can have in the future information about its compilation