### PR TITLE
Add register pool

### DIFF
--- a/Druid/DRCogitDynamicLinearScanRegisterAllocator.class.st
+++ b/Druid/DRCogitDynamicLinearScanRegisterAllocator.class.st
@@ -1,25 +1,12 @@
 Class {
 	#name : #DRCogitDynamicLinearScanRegisterAllocator,
 	#superclass : #DRCogitLinearScanRegisterAllocator,
-	#instVars : [
-		'nextRegister'
-	],
 	#category : #'Druid-Cogit'
 }
-
-{ #category : #allocation }
-DRCogitDynamicLinearScanRegisterAllocator >> allocateRegisterForInterval: anInterval ifPresent: aBlock [
-
-	"Always allocate a new register"
-	| allocatedRegister |
-	allocatedRegister := nextRegister.
-	nextRegister := nextRegister + 1.
-	^ aBlock value: (DRPhysicalGeneralPurposeRegister name: 't', allocatedRegister asString)
-]
 
 { #category : #allocation }
 DRCogitDynamicLinearScanRegisterAllocator >> initialize [
 
 	super initialize.
-	nextRegister := 0
+	registerPool := DRInfiniteRegisterPool new
 ]

--- a/Druid/DRFixedRegisterPool.class.st
+++ b/Druid/DRFixedRegisterPool.class.st
@@ -73,7 +73,44 @@ DRFixedRegisterPool >> takeFloatRegister: aRegister [
 ]
 
 { #category : #allocation }
+DRFixedRegisterPool >> takeFloatingPointRegisterNotIn: inactiveOverlappingRegisters ifPresent: presentBlock [
+
+	self
+		takeRegisterFrom: floatingPointRegisters
+		notIn: inactiveOverlappingRegisters
+		ifPresent: [ :selectedRegister |
+			self takeFloatRegister: selectedRegister.
+			^ presentBlock value: selectedRegister ]
+]
+
+{ #category : #allocation }
 DRFixedRegisterPool >> takeIntegerRegister: aDRPhysicalRegister [ 
 	
 	integerRegisters remove: aDRPhysicalRegister
+]
+
+{ #category : #allocation }
+DRFixedRegisterPool >> takeIntegerRegisterNotIn: inactiveOverlappingRegisters ifPresent: presentBlock [
+
+	self
+		takeRegisterFrom: integerRegisters
+		notIn: inactiveOverlappingRegisters
+		ifPresent: [ :selectedRegister |
+			self takeIntegerRegister: selectedRegister.
+			^ presentBlock value: selectedRegister ]
+]
+
+{ #category : #'private - allocation' }
+DRFixedRegisterPool >> takeRegisterFrom: aCollection notIn: inactiveOverlappingRegisters ifPresent: presentBlock [
+
+	| currentRegisters |
+	currentRegisters := aCollection copy.
+	inactiveOverlappingRegisters do: [ :e |
+		currentRegisters
+			remove: e
+			ifAbsent: [ "not care, we just want to ignore that register..." ] ].
+
+	"If we have registers, take one"
+	currentRegisters ifNotEmpty: [
+		presentBlock value: currentRegisters first ]
 ]

--- a/Druid/DRFixedRegisterPool.class.st
+++ b/Druid/DRFixedRegisterPool.class.st
@@ -1,0 +1,79 @@
+Class {
+	#name : #DRFixedRegisterPool,
+	#superclass : #Object,
+	#instVars : [
+		'integerRegisters',
+		'floatingPointRegisters',
+		'spillRegisters'
+	],
+	#category : #'Druid-LinearScanRegisterAllocation'
+}
+
+{ #category : #accessing }
+DRFixedRegisterPool >> floatingPointRegisters [
+
+	^ floatingPointRegisters
+]
+
+{ #category : #accessing }
+DRFixedRegisterPool >> floatingPointRegisters: anObject [
+
+	floatingPointRegisters := anObject asOrderedCollection
+]
+
+{ #category : #initialization }
+DRFixedRegisterPool >> initialize [
+
+	super initialize.
+	integerRegisters := #().
+	floatingPointRegisters := #().
+	
+]
+
+{ #category : #accessing }
+DRFixedRegisterPool >> integerRegisters [
+
+	^ integerRegisters
+]
+
+{ #category : #accessing }
+DRFixedRegisterPool >> integerRegisters: anObject [
+
+	integerRegisters := anObject asOrderedCollection
+]
+
+{ #category : #allocation }
+DRFixedRegisterPool >> returnFloatRegister: aRegister [
+
+	floatingPointRegisters addFirst: aRegister
+]
+
+{ #category : #allocation }
+DRFixedRegisterPool >> returnIntegerRegister: aPhisicalRegister [
+
+	integerRegisters addFirst: aPhisicalRegister
+]
+
+{ #category : #accessing }
+DRFixedRegisterPool >> spillRegisters [
+
+	^ spillRegisters
+]
+
+{ #category : #accessing }
+DRFixedRegisterPool >> spillRegisters: anObject [
+
+	spillRegisters := anObject
+]
+
+{ #category : #allocation }
+DRFixedRegisterPool >> takeFloatRegister: aRegister [ 
+	
+	floatingPointRegisters remove: aRegister
+]
+
+{ #category : #allocation }
+DRFixedRegisterPool >> takeIntegerRegister: aDRPhysicalRegister [ 
+	
+	integerRegisters remove: aDRPhysicalRegister
+]

--- a/Druid/DRFixedRegisterPool.class.st
+++ b/Druid/DRFixedRegisterPool.class.st
@@ -42,6 +42,12 @@ DRFixedRegisterPool >> integerRegisters: anObject [
 	integerRegisters := anObject asOrderedCollection
 ]
 
+{ #category : #'as yet unclassified' }
+DRFixedRegisterPool >> peekSpillRegister [
+
+	^ spillRegisters first
+]
+
 { #category : #allocation }
 DRFixedRegisterPool >> returnFloatRegister: aRegister [
 
@@ -54,6 +60,12 @@ DRFixedRegisterPool >> returnIntegerRegister: aPhisicalRegister [
 	integerRegisters addFirst: aPhisicalRegister
 ]
 
+{ #category : #'as yet unclassified' }
+DRFixedRegisterPool >> returnSpillRegister: aRegister [
+
+	 spillRegisters addFirst: aRegister
+]
+
 { #category : #accessing }
 DRFixedRegisterPool >> spillRegisters [
 
@@ -61,9 +73,9 @@ DRFixedRegisterPool >> spillRegisters [
 ]
 
 { #category : #accessing }
-DRFixedRegisterPool >> spillRegisters: anObject [
+DRFixedRegisterPool >> spillRegisters: aCollection [
 
-	spillRegisters := anObject
+	spillRegisters := aCollection asOrderedCollection
 ]
 
 { #category : #allocation }
@@ -113,4 +125,10 @@ DRFixedRegisterPool >> takeRegisterFrom: aCollection notIn: inactiveOverlappingR
 	"If we have registers, take one"
 	currentRegisters ifNotEmpty: [
 		presentBlock value: currentRegisters first ]
+]
+
+{ #category : #'as yet unclassified' }
+DRFixedRegisterPool >> takeSpillRegister [
+
+	^ spillRegisters removeFirst
 ]

--- a/Druid/DRInfiniteRegisterPool.class.st
+++ b/Druid/DRInfiniteRegisterPool.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #DRInfiniteRegisterPool,
+	#superclass : #Object,
+	#instVars : [
+		'integerRegisters',
+		'floatingPointRegisters',
+		'spillRegisters',
+		'nextId'
+	],
+	#category : #'Druid-LinearScanRegisterAllocation'
+}

--- a/Druid/DRInfiniteRegisterPool.class.st
+++ b/Druid/DRInfiniteRegisterPool.class.st
@@ -4,8 +4,91 @@ Class {
 	#instVars : [
 		'integerRegisters',
 		'floatingPointRegisters',
-		'spillRegisters',
 		'nextId'
 	],
 	#category : #'Druid-LinearScanRegisterAllocation'
 }
+
+{ #category : #allocation }
+DRInfiniteRegisterPool >> createNewRegister [
+
+	| newRegister |
+	newRegister := 'T', nextId asString.
+	nextId := nextId + 1.
+	^ DRPhysicalGeneralPurposeRegister name: newRegister
+]
+
+{ #category : #initialization }
+DRInfiniteRegisterPool >> initialize [
+
+	super initialize.
+	nextId := 0.
+	
+	integerRegisters := Stack new.
+	floatingPointRegisters := Stack new.
+]
+
+{ #category : #allocation }
+DRInfiniteRegisterPool >> returnFloatRegister: aRegister [
+
+	floatingPointRegisters push: aRegister
+]
+
+{ #category : #allocation }
+DRInfiniteRegisterPool >> returnIntegerRegister: aRegister [
+
+	integerRegisters push: aRegister
+]
+
+{ #category : #allocation }
+DRInfiniteRegisterPool >> takeFloatRegister: aRegister [ 
+	
+	floatingPointRegisters remove: aRegister
+]
+
+{ #category : #allocation }
+DRInfiniteRegisterPool >> takeFloatingPointRegisterNotIn: inactiveOverlappingRegisters ifPresent: presentBlock [
+
+	self
+		takeRegisterFrom: floatingPointRegisters
+		notIn: inactiveOverlappingRegisters
+		ifPresent: [ :selectedRegister |
+			self takeFloatRegister: selectedRegister.
+			^ presentBlock value: selectedRegister ].
+	
+	^ presentBlock value: self createNewRegister
+]
+
+{ #category : #allocation }
+DRInfiniteRegisterPool >> takeIntegerRegister: aDRPhysicalRegister [ 
+	
+	integerRegisters remove: aDRPhysicalRegister
+]
+
+{ #category : #allocation }
+DRInfiniteRegisterPool >> takeIntegerRegisterNotIn: inactiveOverlappingRegisters ifPresent: presentBlock [
+
+	self
+		takeRegisterFrom: integerRegisters
+		notIn: inactiveOverlappingRegisters
+		ifPresent: [ :selectedRegister |
+			self takeIntegerRegister: selectedRegister.
+			^ presentBlock value: selectedRegister ].
+
+	^ presentBlock value: self createNewRegister
+]
+
+{ #category : #'private - allocation' }
+DRInfiniteRegisterPool >> takeRegisterFrom: aCollection notIn: inactiveOverlappingRegisters ifPresent: presentBlock [
+
+	| currentRegisters |
+	currentRegisters := aCollection copy.
+	inactiveOverlappingRegisters do: [ :e |
+		currentRegisters
+			remove: e
+			ifAbsent: [ "not care, we just want to ignore that register..." ] ].
+
+	"If we have registers, take one"
+	currentRegisters ifNotEmpty: [
+		presentBlock value: currentRegisters first ]
+]

--- a/Druid/DRLinearScanRegisterAllocator.class.st
+++ b/Druid/DRLinearScanRegisterAllocator.class.st
@@ -17,29 +17,28 @@ Class {
 
 { #category : #allocation }
 DRLinearScanRegisterAllocator >> allocateRegisterForInterval: aDRLiveRegisterInterval ifPresent: presentBlock [
-	
-	| currentRegisters isFloat inactiveOverlappingRegisters |
-	
-	isFloat := aDRLiveRegisterInterval definitions anyOne type isFloatType.
-	
+
+	| isFloat inactiveOverlappingRegisters |
+	isFloat := aDRLiveRegisterInterval definitions anyOne type
+		           isFloatType.
+
 	"Do not consider those that are in inactive intervals so we don't scratch them"
 	inactiveOverlappingRegisters := inactiveIntervals
-		select: [ :e | e overlaps: aDRLiveRegisterInterval ]
-		thenCollect: [ :e | e location ].
+		                                select: [ :e |
+		                                e overlaps: aDRLiveRegisterInterval ]
+		                                thenCollect: [ :e | e location ].
 
-	currentRegisters := isFloat
-		ifTrue: [ registerPool floatingPointRegisters copy ]
-		ifFalse: [ registerPool integerRegisters copy ].
-
-	inactiveOverlappingRegisters do: [ :e |
-		currentRegisters remove: e ifAbsent: [ "not care, we just want to ignore that register..." ].
-	].
-
-	"If we have registers, take one"	
-	currentRegisters ifNotEmpty: [ | selectedRegister |
-		selectedRegister := currentRegisters first.
-		self takeRegister: selectedRegister.
-		^ presentBlock value: selectedRegister ]
+	isFloat
+		ifTrue: [
+			registerPool
+				takeFloatingPointRegisterNotIn: inactiveOverlappingRegisters
+				ifPresent: [ :selectedRegister |
+				^ presentBlock value: selectedRegister ] ]
+		ifFalse: [
+			registerPool
+				takeIntegerRegisterNotIn: inactiveOverlappingRegisters
+				ifPresent: [ :selectedRegister |
+				^ presentBlock value: selectedRegister ] ]
 ]
 
 { #category : #allocation }

--- a/Druid/DRLinearScanRegisterAllocator.class.st
+++ b/Druid/DRLinearScanRegisterAllocator.class.st
@@ -18,25 +18,22 @@ Class {
 { #category : #allocation }
 DRLinearScanRegisterAllocator >> allocateRegisterForInterval: aDRLiveRegisterInterval ifPresent: presentBlock [
 	
-	| currentIntegerRegisters currentFloatRegisters currentRegisters |
+	| currentRegisters isFloat inactiveOverlappingRegisters |
 	
-	"Start considering all available registers"
-	currentIntegerRegisters := registerPool integerRegisters copy.
-	currentFloatRegisters := registerPool floatingPointRegisters copy.
-
-	"Remove those that are in inactive intervals so we don't scratch them"
-	inactiveIntervals
+	isFloat := aDRLiveRegisterInterval definitions anyOne type isFloatType.
+	
+	"Do not consider those that are in inactive intervals so we don't scratch them"
+	inactiveOverlappingRegisters := inactiveIntervals
 		select: [ :e | e overlaps: aDRLiveRegisterInterval ]
-		thenDo: [ :e |
-			currentIntegerRegisters remove: e location ifAbsent: [ "ignore if it is in use" ].
-			currentFloatRegisters remove: e location ifAbsent: [ "ignore if it is in use" ]. ].
-	unhandledIntervals
-		select: [ :e | e location notNil and: [ e overlaps: aDRLiveRegisterInterval ] ]
-		thenDo: [ :e | e halt ].
+		thenCollect: [ :e | e location ].
 
-	currentRegisters := aDRLiveRegisterInterval definitions anyOne type isFloatType
-		ifTrue: [ currentFloatRegisters ]
-		ifFalse: [ currentIntegerRegisters ].
+	currentRegisters := isFloat
+		ifTrue: [ registerPool floatingPointRegisters copy ]
+		ifFalse: [ registerPool integerRegisters copy ].
+
+	inactiveOverlappingRegisters do: [ :e |
+		currentRegisters remove: e ifAbsent: [ "not care, we just want to ignore that register..." ].
+	].
 
 	"If we have registers, take one"	
 	currentRegisters ifNotEmpty: [ | selectedRegister |

--- a/Druid/DRLinearScanRegisterAllocator.class.st
+++ b/Druid/DRLinearScanRegisterAllocator.class.st
@@ -4,7 +4,6 @@ Class {
 	#instVars : [
 		'blocks',
 		'liveSets',
-		'spillRegisters',
 		'controlFlowGraph',
 		'activeIntervals',
 		'inactiveIntervals',
@@ -131,7 +130,7 @@ DRLinearScanRegisterAllocator >> assignRegisterToResultInInstruction: i [
 
 	allocatedLocation := self allocatedRegisterFor: i.
 	allocatedRegister := allocatedLocation isMemoryAddress
-		                     ifTrue: [ spillRegisters first ]
+		                     ifTrue: [ registerPool peekSpillRegister ]
 		                     ifFalse: [ allocatedLocation ].
 
 	i result: allocatedRegister.
@@ -187,9 +186,7 @@ DRLinearScanRegisterAllocator >> assignRegistersToOperandsInInstruction: i [
 		(liveSets includesKey: op) ifTrue: [ 
 			allocatedLocation := self allocatedRegisterFor: op.
 			allocatedRegister := allocatedLocation isMemoryAddress
-				                     ifTrue: [ 
-				                     usedSpillRegisters addFirst:
-					                     spillRegisters removeFirst ]
+				                     ifTrue: [ usedSpillRegisters addFirst: registerPool takeSpillRegister ]
 				                     ifFalse: [ allocatedLocation ].
 
 			allocatedLocation isMemoryAddress ifTrue: [ | load |
@@ -205,7 +202,7 @@ DRLinearScanRegisterAllocator >> assignRegistersToOperandsInInstruction: i [
 		op isVirtualRegister ifTrue: [ 
 			op physicalRegister: allocatedRegister ] ] ].
 
-	usedSpillRegisters do: [ :each | spillRegisters addFirst: each ]
+	usedSpillRegisters do: [ :each | registerPool returnSpillRegister: each ]
 ]
 
 { #category : #'live-analysis' }
@@ -440,7 +437,7 @@ DRLinearScanRegisterAllocator >> selectIntervalToSpill [
 { #category : #accessing }
 DRLinearScanRegisterAllocator >> spillRegisters: aCollection [
 	
-	spillRegisters := aCollection asOrderedCollection
+	registerPool spillRegisters: aCollection
 ]
 
 { #category : #allocation }

--- a/Druid/DRLinearScanRegisterAllocator.class.st
+++ b/Druid/DRLinearScanRegisterAllocator.class.st
@@ -10,8 +10,6 @@ Class {
 		'inactiveIntervals',
 		'unhandledIntervals',
 		'spillingStrategy',
-		'availableIntegerRegisters',
-		'availableFloatingPointRegisters',
 		'registerPool'
 	],
 	#category : #'Druid-LinearScanRegisterAllocation'
@@ -23,8 +21,8 @@ DRLinearScanRegisterAllocator >> allocateRegisterForInterval: aDRLiveRegisterInt
 	| currentIntegerRegisters currentFloatRegisters currentRegisters |
 	
 	"Start considering all available registers"
-	currentIntegerRegisters := availableIntegerRegisters copy.
-	currentFloatRegisters := availableFloatingPointRegisters copy.
+	currentIntegerRegisters := registerPool integerRegisters copy.
+	currentFloatRegisters := registerPool floatingPointRegisters copy.
 
 	"Remove those that are in inactive intervals so we don't scratch them"
 	inactiveIntervals
@@ -317,7 +315,7 @@ DRLinearScanRegisterAllocator >> controlFlowGraph: aDRControlFlowGraph [
 { #category : #accessing }
 DRLinearScanRegisterAllocator >> floatRegisters: aCollection [ 
 
-	availableFloatingPointRegisters := aCollection asOrderedCollection
+	registerPool floatingPointRegisters: aCollection
 ]
 
 { #category : #initialization }
@@ -325,8 +323,7 @@ DRLinearScanRegisterAllocator >> initialize [
 
 	super initialize.
 	self withFirstSpilling.
-	availableIntegerRegisters := #().
-	availableFloatingPointRegisters := #()
+	registerPool := DRFixedRegisterPool new
 ]
 
 { #category : #'live-analysis' }
@@ -350,7 +347,7 @@ DRLinearScanRegisterAllocator >> instructionsDo: aFullBlockClosure [
 { #category : #accessing }
 DRLinearScanRegisterAllocator >> integerRegisters: aCollection [
 
-	availableIntegerRegisters := aCollection asOrderedCollection
+	registerPool integerRegisters: aCollection
 ]
 
 { #category : #'block-linearization' }
@@ -423,13 +420,13 @@ DRLinearScanRegisterAllocator >> registerPool: aRegisterPool [
 { #category : #allocation }
 DRLinearScanRegisterAllocator >> returnFloatRegister: aPhisicalRegister [
 
-	availableFloatingPointRegisters addFirst: aPhisicalRegister
+	registerPool returnFloatRegister: aPhisicalRegister
 ]
 
 { #category : #allocation }
-DRLinearScanRegisterAllocator >> returnIntegerRegister: aPhisicalRegister [
+DRLinearScanRegisterAllocator >> returnIntegerRegister: aRegister [
 
-	availableIntegerRegisters addFirst: aPhisicalRegister
+	registerPool returnIntegerRegister: aRegister
 ]
 
 { #category : #allocation }
@@ -451,15 +448,15 @@ DRLinearScanRegisterAllocator >> spillRegisters: aCollection [
 ]
 
 { #category : #allocation }
-DRLinearScanRegisterAllocator >> takeFloatRegister: aDRPhysicalRegister [ 
+DRLinearScanRegisterAllocator >> takeFloatRegister: aDRPhysicalRegister [
 	
-	availableFloatingPointRegisters remove: aDRPhysicalRegister
+	registerPool takeFloatRegister: aDRPhysicalRegister
 ]
 
 { #category : #allocation }
-DRLinearScanRegisterAllocator >> takeIntegerRegister: aDRPhysicalRegister [ 
-	
-	availableIntegerRegisters remove: aDRPhysicalRegister
+DRLinearScanRegisterAllocator >> takeIntegerRegister: aRegister [
+
+	registerPool takeIntegerRegister: aRegister
 ]
 
 { #category : #allocation }


### PR DESCRIPTION
Introduce the concept of register pools.
A fixed register pool has a limited number of registers.
When no more registers are available, the register allocator will spill the register into a stack slot.

An infinite register pool always has new registers.
However, it will reuse them when possible (not conflicting live ranges).
This leads to an almost optimal (minimal?) usage of registers, depending on the register allocation algorithm of course.

First part of #55