### PR TITLE
Fix closure creation

### DIFF
--- a/Druid/DRBranchIfCondition.class.st
+++ b/Druid/DRBranchIfCondition.class.st
@@ -57,9 +57,12 @@ DRBranchIfCondition >> condition: aCondition [
 DRBranchIfCondition >> conditionAsJitCompileTimeExpression [
 
 	| fullExpression |
-	fullExpression := self operand1 asJitCompileTimeExpression expression
-	                  , self condition asJitCompileTimeExpressionString
-	                  , self operand2 asJitCompileTimeExpression expression.
+	fullExpression := self isEqualsThanTrueComparison
+		                  ifTrue: [ self nonTrueOperand asJitCompileTimeExpression expression ]
+		                  ifFalse: [
+			                  self operand1 asJitCompileTimeExpression expression
+			                  , self condition asJitCompileTimeExpressionString
+			                  , self operand2 asJitCompileTimeExpression expression ].
 
 	^ fullExpression asDRValue asJitCompileTimeExpression
 ]
@@ -118,6 +121,12 @@ DRBranchIfCondition >> isConditionalLoop [
 ]
 
 { #category : #testing }
+DRBranchIfCondition >> isEqualsThanTrueComparison [
+
+	^ self condition isEqualsThanComparison and: [ self operands includes: true asDRValue ]
+]
+
+{ #category : #testing }
 DRBranchIfCondition >> isJITCompileTimeExpression [
 
 	^ operands allSatisfy: [ :e | e isJITCompileTimeExpression ]
@@ -147,6 +156,15 @@ DRBranchIfCondition >> newTrueBranch: aDRBasicBlock [
 
 	aDRBasicBlock addPredecessor: self basicBlock.
 	^ self trueBranch: aDRBasicBlock
+]
+
+{ #category : #accessing }
+DRBranchIfCondition >> nonTrueOperand [
+
+	self operand1 = true asDRValue ifFalse: [ ^ self operand1 ].
+
+	self assert: self operand2 ~= true asDRValue.
+	^ self operand2
 ]
 
 { #category : #printing }

--- a/Druid/DRCogitCodeGenerator.class.st
+++ b/Druid/DRCogitCodeGenerator.class.st
@@ -442,8 +442,7 @@ DRCogitCodeGenerator >> initialize [
 { #category : #'code-generation' }
 DRCogitCodeGenerator >> innerCompileBlocks: innerBlocks [
 
-	| innerGenerator cfg |
-	cfg := innerBlocks first controlFlowGraph.
+	| innerGenerator |
 	innerGenerator := self innerGenerator.
 	innerGenerator blocks: innerBlocks.
 	innerGenerator generateCodeFromBlocks.

--- a/Druid/DRCogitStackToRegisterMappingGenerator.class.st
+++ b/Druid/DRCogitStackToRegisterMappingGenerator.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'nextVariableIndex',
 		'variables',
-		'markDeadCode'
+		'markDeadCode',
+		'parent'
 	],
 	#category : #'Druid-Cogit'
 }
@@ -13,6 +14,8 @@ Class {
 DRCogitStackToRegisterMappingGenerator >> allocateVariable: aDRResult [
 
 	| temporaryVariableNode variableIndex |
+	parent ifNotNil: [ ^ parent allocateVariable: aDRResult ].
+	
 	aDRResult isNoResult ifTrue: [ ^ self ].
 	variables at: aDRResult ifPresent: [ :var | ^ var ].
 
@@ -78,9 +81,11 @@ DRCogitStackToRegisterMappingGenerator >> innerGenerator [
 
 	| innerGenerator |
 	innerGenerator := self copy.
-	innerGenerator variables: variables copy.
-	innerGenerator deferredBranches: deferredBranches copy.
+	innerGenerator parent: self.
 	innerGenerator generatorMethodBuilder: DRGeneratorMethodBuilder new.
+	
+	self flag: #TODO. "If we have a reference to the parent then copying the state could be not needed"
+	innerGenerator deferredBranches: deferredBranches copy.
 	^ innerGenerator
 ]
 
@@ -102,6 +107,12 @@ DRCogitStackToRegisterMappingGenerator >> moveToReg: aRBMessageNode from: aDRIns
 			 receiver: aRBMessageNode
 			 selector: #copyToReg:
 			 arguments: { (RBVariableNode named: temporaryVariableNode) })
+]
+
+{ #category : #accessing }
+DRCogitStackToRegisterMappingGenerator >> parent: aDRCogitGenerator [
+
+	parent := aDRCogitGenerator
 ]
 
 { #category : #'ir-to-ast' }

--- a/Druid/DRCogitStackToRegisterMappingGenerator.class.st
+++ b/Druid/DRCogitStackToRegisterMappingGenerator.class.st
@@ -230,7 +230,6 @@ DRCogitStackToRegisterMappingGenerator >> visitClosureCreation: aDRClosureCreati
 	"Create full closure intrinsic uses ReceiverResultReg, SendNumArgsReg and ClassReg."
 
 	| copy |
-	1 halt.
 	"Save registers live"
 	self flag: #TODO. "Validate that the register was not already taken"
 	self saveRegisterLiveMask:

--- a/Druid/DRCogitStackToRegisterMappingGenerator.class.st
+++ b/Druid/DRCogitStackToRegisterMappingGenerator.class.st
@@ -29,28 +29,18 @@ DRCogitStackToRegisterMappingGenerator >> allocateVariable: aDRResult [
 	variableIndex := nextVariableIndex.
 	nextVariableIndex := nextVariableIndex + 1.
 
-	temporaryVariableNode := RBVariableNode named:
-		                         't' , variableIndex asString.
+	temporaryVariableNode := RBVariableNode named: 't' , variableIndex asString.
 	variables at: aDRResult put: temporaryVariableNode name.
 
 	generatorMethodBuilder addVariableNamed: temporaryVariableNode name.
-	generatorMethodBuilder addStatement: (RBAssignmentNode
-			 variable: temporaryVariableNode copy
-			 value: (RBMessageNode
-					  receiver: RBVariableNode selfNode
-					  selector: #allocateRegNotConflictingWith:ifNone:
-					  arguments: {
-							  (RBVariableNode named: 'live').
-							  (RBVariableNode named: '[ ^ self unknownBytecode ]') })).
-	generatorMethodBuilder addStatement: (RBAssignmentNode
-			 variable: (RBVariableNode named: 'live')
-			 value: (RBMessageNode
-					  receiver: (RBVariableNode named: 'live')
-					  selector: #bitOr:
-					  arguments: { (RBMessageNode
-							   receiver: RBVariableNode selfNode
-							   selector: #registerMaskFor:
-							   arguments: { temporaryVariableNode copy }) })).
+	generatorMethodBuilder addStatement:
+		(RBAssignmentNode variable: temporaryVariableNode copy value: (RBMessageNode
+				  receiver: RBVariableNode selfNode
+				  selector: #allocateRegNotConflictingWith:ifNone:
+				  arguments: {
+						  (RBVariableNode named: 'live').
+						  (RBVariableNode named: '[ ^ self unknownBytecode ]') })).
+	self saveRegisterLiveMask: temporaryVariableNode.
 
 	^ temporaryVariableNode name
 ]
@@ -136,6 +126,19 @@ DRCogitStackToRegisterMappingGenerator >> rtlExpressionForValue: aValue [
 
 	variables at: aValue result ifPresent: [ :var | ^ RBVariableNode named: var ].
 	^ super rtlExpressionForValue: aValue
+]
+
+{ #category : #helpers }
+DRCogitStackToRegisterMappingGenerator >> saveRegisterLiveMask: temporaryVariableNode [
+
+	generatorMethodBuilder addStatement:
+		(RBAssignmentNode variable: (RBVariableNode named: 'live') value: (RBMessageNode
+				  receiver: (RBVariableNode named: 'live')
+				  selector: #bitOr:
+				  arguments: { (RBMessageNode
+						   receiver: RBVariableNode selfNode
+						   selector: #registerMaskFor:
+						   arguments: { temporaryVariableNode copy }) }))
 ]
 
 { #category : #visiting }
@@ -224,20 +227,50 @@ DRCogitStackToRegisterMappingGenerator >> visitCall: aDRCall [
 
 { #category : #visiting }
 DRCogitStackToRegisterMappingGenerator >> visitClosureCreation: aDRClosureCreation [
+	"Create full closure intrinsic uses ReceiverResultReg, SendNumArgsReg and ClassReg."
 
-	| allocatedTemporary |
-	allocatedTemporary := self allocateVariable:
-		                      aDRClosureCreation result.
+	| copy |
+	1 halt.
+	"Save registers live"
+	self flag: #TODO. "Validate that the register was not already taken"
+	self saveRegisterLiveMask:
+		(RBVariableNode named: DRPhysicalGeneralPurposeRegister receiverResultReg name).
+	self saveRegisterLiveMask:
+		(RBVariableNode named: DRPhysicalGeneralPurposeRegister sendNumArgsReg name).
+	self saveRegisterLiveMask:
+		(RBVariableNode named: DRPhysicalGeneralPurposeRegister classReg name).
+
+	"Free ReceiverResultReg value"
+	generatorMethodBuilder addStatement: (RBMessageNode
+			 receiver: RBVariableNode selfNode
+			 selector: #voidReceiverResultRegContainsSelf).
+
+	"Allocate registers for call the trampoline"
+	generatorMethodBuilder addStatement: (RBMessageNode
+			 receiver: RBVariableNode selfNode
+			 selector: #ssAllocateCallReg:and:and:
+			 arguments: {
+					 (RBVariableNode named: DRPhysicalGeneralPurposeRegister receiverResultReg name).
+					 (RBVariableNode named: DRPhysicalGeneralPurposeRegister sendNumArgsReg name).
+					 (RBVariableNode named: DRPhysicalGeneralPurposeRegister classReg name) }).
+
+	"Create the closure and save it in ReceiverResultReg"
 	generatorMethodBuilder addStatement: (RBMessageNode
 			 receiver: RBVariableNode selfNode
 			 selector:
 			 #genCreateFullClosureInIndex:numCopied:ignoreContext:contextNumArgs:large:inBlock:intoRegister:
-			 arguments: (aDRClosureCreation operands collect: [ :e |
+			 arguments: (aDRClosureCreation operands allButLast collect: [ :e |
 					  (e rtlPushArgumentExpressions: self) first ]) , {
-					 (RBVariableNode named:
-						  '(coInterpreter methodNeedsLargeContext: methodObj)').
-					 (RBVariableNode named: 'inBlock') }
-				 , { (RBVariableNode named: allocatedTemporary) })
+					 (RBVariableNode named: 'methodOrBlockNumArgs').
+					 (RBVariableNode named: '(coInterpreter methodNeedsLargeContext: methodObj)').
+					 (RBVariableNode named: 'inBlock').
+					 (RBVariableNode named: DRPhysicalGeneralPurposeRegister receiverResultReg name) }).
+
+	"Copy from ReceiverResultReg to result register"
+	copy := DRCopy
+		        operands: { DRPhysicalGeneralPurposeRegister receiverResultReg }
+		        result: aDRClosureCreation result.
+	copy acceptVisitor: self
 ]
 
 { #category : #visiting }

--- a/Druid/DRPhysicalGeneralPurposeRegister.class.st
+++ b/Druid/DRPhysicalGeneralPurposeRegister.class.st
@@ -4,6 +4,24 @@ Class {
 	#category : #'Druid-IR'
 }
 
+{ #category : #factory }
+DRPhysicalGeneralPurposeRegister class >> classReg [
+
+	^ self name: 'ClassReg'
+]
+
+{ #category : #factory }
+DRPhysicalGeneralPurposeRegister class >> receiverResultReg [
+
+	^ self name: 'ReceiverResultReg'
+]
+
+{ #category : #factory }
+DRPhysicalGeneralPurposeRegister class >> sendNumArgsReg [
+
+	^ self name: 'SendNumArgsReg'
+]
+
 { #category : #visiting }
 DRPhysicalGeneralPurposeRegister >> acceptVisitor: aVisitor [
 


### PR DESCRIPTION
Fix the compilation of `gen_ExtPushFullClosureBytecode` 🥳 

- Saving fixed register used for the closure creation intrinsic
- Avoiding `= true` in conditions
- Allocate dynamic registers outside the loops and staged paths


DruidJIT -> https://github.com/pharo-project/pharo-vm/pull/725/