### PR TITLE
Added conditional compilation

### DIFF
--- a/Druid-Tests/DRPrimitiveScenarioCompilationTest.class.st
+++ b/Druid-Tests/DRPrimitiveScenarioCompilationTest.class.st
@@ -624,6 +624,18 @@ DRPrimitiveScenarioCompilationTest >> testCompiledPrimitiveWithTwoArgs [
 	self assert: machineSimulator receiverRegisterValue equals: 2
 ]
 
+{ #category : #'tests-comparisons-floats' }
+DRPrimitiveScenarioCompilationTest >> testConditionalCompilationWithNoConditionGiven [
+
+	self
+		compileDruidPrimitive: #primitiveWithConditionalCompilation
+		with: [ :druid | druid addCompilerOption: #condition ].
+
+	self executePrimitiveWithReceiver: 0 withArguments: {  }.
+
+	self assert: machineSimulator receiverRegisterValue equals: 17
+]
+
 { #category : #'tests-types' }
 DRPrimitiveScenarioCompilationTest >> testConstantFloatAsInteger [
 

--- a/Druid-Tests/DruidTestInterpreter.class.st
+++ b/Druid-Tests/DruidTestInterpreter.class.st
@@ -1783,6 +1783,14 @@ DruidTestInterpreter >> primitiveUint8AtPut [
 ]
 
 { #category : #'as yet unclassified' }
+DruidTestInterpreter >> primitiveWithConditionalCompilation [
+
+	<numberOfArguments: 0>
+	self druidIf: #condition do: [ ^ self pop: 1 thenPush: 17 ].
+	self pop: 1 thenPush: 42
+]
+
+{ #category : #'as yet unclassified' }
 DruidTestInterpreter >> primitiveWithDeadCode [
 
 	<numberOfArguments: 0>

--- a/Druid/DRAbstractCompilerCompiler.class.st
+++ b/Druid/DRAbstractCompilerCompiler.class.st
@@ -10,7 +10,8 @@ Class {
 		'optimisations',
 		'codeGenerator',
 		'customisation',
-		'irGenerator'
+		'irGenerator',
+		'compilerOptions'
 	],
 	#category : #'Druid-CompilerCompiler'
 }
@@ -21,6 +22,12 @@ DRAbstractCompilerCompiler class >> forInterpreter: anAbstractInterpreter [
 	^ self new
 		interpreter: anAbstractInterpreter;
 		yourself
+]
+
+{ #category : #accessing }
+DRAbstractCompilerCompiler >> addCompilerOption: anOption [
+
+	compilerOptions add: anOption
 ]
 
 { #category : #api }
@@ -54,6 +61,11 @@ DRAbstractCompilerCompiler >> compilerClass [
 DRAbstractCompilerCompiler >> compilerClass: anObject [
 
 	compilerClass := anObject
+]
+
+{ #category : #accessing }
+DRAbstractCompilerCompiler >> compilerOptions [
+	^ compilerOptions
 ]
 
 { #category : #accessing }
@@ -146,7 +158,8 @@ DRAbstractCompilerCompiler >> initialize [
 
 	codeGenerator := DRCogitCodeGenerator new.
 	customisation := DRNonePrimitiveCustomisation new.
-	irGenerator := self newIRGenerator
+	irGenerator := self newIRGenerator.
+	compilerOptions := Set new
 ]
 
 { #category : #'generation-IR' }
@@ -226,7 +239,7 @@ DRAbstractCompilerCompiler >> irGenerator: aDRIRGenerator [
 { #category : #'generation-IR' }
 DRAbstractCompilerCompiler >> newIRGenerator [
 
-	^ DRIRGenerator new
+	^ DRIRGenerator new compiler: self
 ]
 
 { #category : #accessing }

--- a/Druid/DRIRGenerator.class.st
+++ b/Druid/DRIRGenerator.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : #DRIRGenerator,
 	#superclass : #Object,
 	#instVars : [
+		'compiler',
 		'specialCases',
 		'currentBasicBlock',
 		'firstBasicBlock',
@@ -158,6 +159,24 @@ DRIRGenerator >> branchFrom: startingBasicBlock onEdge: anEdgeBlock doing: aBloc
 ]
 
 { #category : #accessing }
+DRIRGenerator >> compiler [
+
+	^ compiler
+]
+
+{ #category : #accessing }
+DRIRGenerator >> compiler: anObject [
+
+	compiler := anObject
+]
+
+{ #category : #accessing }
+DRIRGenerator >> compilerOptions [
+
+	^ self compiler compilerOptions
+]
+
+{ #category : #accessing }
 DRIRGenerator >> controlFlowGraph: aDRControlFlowGraph [
 
 	controlFlowGraph := aDRControlFlowGraph
@@ -195,6 +214,24 @@ DRIRGenerator >> currentMethod [
 DRIRGenerator >> currentOperandStack [
 
 	^ executionState vmOperandStack
+]
+
+{ #category : #accessing }
+DRIRGenerator >> druidConditionalCompilationWith: aRBMessageNode [
+
+	| condition |
+	condition := aRBMessageNode arguments first value.
+	^ (self compilerOptions includes: condition)
+		ifTrue: [
+			| block |
+			aRBMessageNode arguments second acceptVisitor: self.
+			block := self popOperand simplify.
+			block isDRBlockClosure ifFalse: [
+				self error: 'Only consider blocks' ].
+			block blockNode arguments size > 0 ifTrue: [
+				self error: 'Only consider blocks with no arguments' ].
+			self interpretCode: block receiver: block arguments: #(  ) ]
+		ifFalse: [ self noop: aRBMessageNode ]
 ]
 
 { #category : #'execution state' }
@@ -276,6 +313,7 @@ DRIRGenerator >> initializeSpecialCases [
 	"Control flow and comparisons"
 	specialCases at: #druidStageable: put: #interpretStageableBlockWith:.
 	specialCases at: #druidIgnore: put: #ignoreMessageWith:.
+	specialCases at: #druidIf:do: put: #druidConditionalCompilationWith:.
 	specialCases at: #interpreterIgnore: put: #interpretBlockArgumentValueWith:.
 	specialCases at: #druidFail put: #interpretDruidFailWith:.
 	specialCases at: #value put: #interpretBlockValueWith:.

--- a/Druid/DRMethodCompilerCompiler.class.st
+++ b/Druid/DRMethodCompilerCompiler.class.st
@@ -38,7 +38,7 @@ DRMethodCompilerCompiler >> configureForCompilerClass: aCompilerClass [
 { #category : #'instance creation' }
 DRMethodCompilerCompiler >> newIRGenerator [
 
-	^ DRMethodIRGenerator new
+	^ DRMethodIRGenerator new compiler: self
 ]
 
 { #category : #'generation-IR' }

--- a/Druid/DRPrimitiveCompilerCompiler.class.st
+++ b/Druid/DRPrimitiveCompilerCompiler.class.st
@@ -105,7 +105,7 @@ DRPrimitiveCompilerCompiler >> initialize [
 { #category : #accessing }
 DRPrimitiveCompilerCompiler >> newIRGenerator [
 
-	^ DRPrimitiveIRGenerator new
+	^ DRPrimitiveIRGenerator new compiler: self
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Conditionally compiled code can be expressed as `druidIf:do:`

```smalltalk
 	self druidIf: #condition do: [ ^ self pop: 1 thenPush: 17 ].
```

Compilation options can be added through `addCompilerOption:`

```smalltalk
druid addCompilerOption: #condition
```