### PR TITLE
Peephole arithmetic optimization

### DIFF
--- a/Druid-Tests/DRCogitCanonicaliserTest.class.st
+++ b/Druid-Tests/DRCogitCanonicaliserTest.class.st
@@ -591,7 +591,8 @@ DRCogitCanonicaliserTest >> testSimplifySubtractionOfAddition [
 	DRSCCP new applyTo:cfg.
 	DRDeadCodeElimination new applyTo: cfg.
 
-	"The two additions should be simplified to a single one"
+	"Constants operations should be simplified"
 	self assert: basicBlock instructions size equals: 4.
+	self assert: basicBlock instructions second isAdd.
 	self assert: basicBlock instructions second operand2 value equals: -8 "17 - 25".
 ]

--- a/Druid-Tests/DRCogitCanonicaliserTest.class.st
+++ b/Druid-Tests/DRCogitCanonicaliserTest.class.st
@@ -581,7 +581,6 @@ DRCogitCanonicaliserTest >> testSimplifySubtractionOfAddition [
 	"(A + Constant1) - Constant2 => A + (Constant1 - Constant2)"
 	basicBlock := cfg newBasicBlockWith: [ :block | | r0 r1 r2 |
 		r0 := block loadFramePointer.
-		"Two additions of constants over a variable value"
 		r1 := block add: r0 to: 17.
 		r2 := block subtract: 25 from: r1.
 		"Store the value so it is not treated as dead code"

--- a/Druid-Tests/DRCogitCanonicaliserTest.class.st
+++ b/Druid-Tests/DRCogitCanonicaliserTest.class.st
@@ -572,3 +572,27 @@ DRCogitCanonicaliserTest >> testSimplifyStoreBaseOffset [
 	self assert: basicBlock instructions second address offset value equals: 17.
 	self assert: basicBlock instructions second address base value equals: basicBlock instructions first.
 ]
+
+{ #category : 'tests' }
+DRCogitCanonicaliserTest >> testSimplifySubtractionOfAddition [
+
+	| cfg basicBlock |
+	cfg := DRControlFlowGraph new.
+	"(A + Constant1) - Constant2 => A + (Constant1 - Constant2)"
+	basicBlock := cfg newBasicBlockWith: [ :block | | r0 r1 r2 |
+		r0 := block loadFramePointer.
+		"Two additions of constants over a variable value"
+		r1 := block add: r0 to: 17.
+		r2 := block subtract: 25 from: r1.
+		"Store the value so it is not treated as dead code"
+		block storeSInt64: r2 at: 888 ].
+	cfg initialBasicBlock jumpTo: basicBlock.
+
+	DRCogitCanonicaliser new applyTo: cfg.
+	DRSCCP new applyTo:cfg.
+	DRDeadCodeElimination new applyTo: cfg.
+
+	"The two additions should be simplified to a single one"
+	self assert: basicBlock instructions size equals: 4.
+	self assert: basicBlock instructions second operand2 value equals: -8 "17 - 25".
+]

--- a/Druid/DRCogitCanonicaliser.class.st
+++ b/Druid/DRCogitCanonicaliser.class.st
@@ -1,15 +1,27 @@
 Class {
 	#name : 'DRCogitCanonicaliser',
 	#superclass : 'DROptimisation',
+	#instVars : [
+		'worklist'
+	],
 	#category : 'Druid-Cogit',
 	#package : 'Druid',
 	#tag : 'Cogit'
 }
 
+{ #category : 'visiting' }
+DRCogitCanonicaliser >> addToWorklist: instruction [
+
+	worklist add: instruction.
+
+]
+
 { #category : 'accessing' }
 DRCogitCanonicaliser >> applyTo: cfg [
 
-	cfg instructions copy do: [ :e | e acceptVisitor: self ]
+	worklist := cfg instructions reversed.
+	[ worklist isEmpty ] whileFalse: [
+		worklist removeLast acceptVisitor: self ]
 ]
 
 { #category : 'visiting' }
@@ -451,11 +463,17 @@ DRCogitCanonicaliser >> visitSubstract: aDRSubtract [
 		 aDRSubtract users allSatisfy: [ :e |
 			 e isAdd or: [ e isSubtract or: [ e isLoad or: [ e isStore ] ] ] ] ])
 		ifTrue: [
-			aDRSubtract replaceBy: (DRAdd
+			| newInstruction |
+			newInstruction := DRAdd
 					 operands: {
 							 aDRSubtract subtrahend value negated asDRValue.
 							 aDRSubtract minuend }
-					 result: aDRSubtract result) ]
+					 result: aDRSubtract result.
+
+			aDRSubtract replaceBy: newInstruction.
+			aDRSubtract minuend isAdd ifTrue: [
+				"Maybe the additions can be further canonicalised"
+				self addToWorklist: newInstruction ] ]
 ]
 
 { #category : 'visiting' }


### PR DESCRIPTION
Cases like `(var + const1) - const2` were not properly canonicalized in a single pass:

    - Nothing happened on the + operation
    - Then the - operation was converted to a +    ---->   `(var + const1) + (-const2)`
    - Another pass was needed to convert that to `(var + (const1 + (-const2))`
Now, it uses a worklist algorithm to determine whether to retry canonicalization on one instruction
For now, the only case I added is: when a substraction is changed to an addition, retry canonicalising the addition

Fixes: #171