### PR TITLE
Fix inline collision name

### DIFF
--- a/Druid-Tests/DRBytecodeGeneratorTest.class.st
+++ b/Druid-Tests/DRBytecodeGeneratorTest.class.st
@@ -236,6 +236,12 @@ DRBytecodeGeneratorTest >> testMethodInlineSelfSettingInstVar [
 ]
 
 { #category : 'tests' }
+DRBytecodeGeneratorTest >> testMethodInlineToDo [
+
+	self assertCompilationFor: #methodWithToDo fromClass: DruidTestInterpreter
+]
+
+{ #category : 'tests' }
 DRBytecodeGeneratorTest >> testMethodManyReturns [
 
 	self assertCompilationFor: #methodWithThreeNonLocalReturn fromClass: DruidTestInterpreter

--- a/Druid-Tests/DRBytecodeGeneratorTest.class.st
+++ b/Druid-Tests/DRBytecodeGeneratorTest.class.st
@@ -242,6 +242,12 @@ DRBytecodeGeneratorTest >> testMethodInlineToDo [
 ]
 
 { #category : 'tests' }
+DRBytecodeGeneratorTest >> testMethodInlineToDoInner [
+
+	self assertCompilationFor: #methodWithTwoToDos fromClass: DruidTestInterpreter
+]
+
+{ #category : 'tests' }
 DRBytecodeGeneratorTest >> testMethodManyReturns [
 
 	self assertCompilationFor: #methodWithThreeNonLocalReturn fromClass: DruidTestInterpreter

--- a/Druid-Tests/DRBytecodeGeneratorTest.class.st
+++ b/Druid-Tests/DRBytecodeGeneratorTest.class.st
@@ -210,14 +210,12 @@ DRBytecodeGeneratorTest >> testMethodInline [
 { #category : 'tests' }
 DRBytecodeGeneratorTest >> testMethodInlineObjectAccessInstVar [
 
-	self skip. "need to repass this after we handle inlining"
 	self assertCompilationFor: #basicInlineMethodAccesInstVar fromClass: DruidTestInterpreter checkByteCode: 'send: #instVarAt:'
 ]
 
 { #category : 'tests' }
 DRBytecodeGeneratorTest >> testMethodInlineObjectSettingInstVar [
 
-	self skip. "need to repass this after we handle inlining"
 	self assertCompilationFor: #basicInlineMethodSettingInstVar fromClass: DruidTestInterpreter checkByteCode: 'send: #instVarAt:put:'
 ]
 
@@ -572,8 +570,6 @@ DRBytecodeGeneratorTest >> testMethodWithEarlyReturn2 [
 DRBytecodeGeneratorTest >> testMethodWithTypeCheck [
 
 	| method result |
-	
-	self skip: 'Depends on the inlining'.
 	
 	compilerCompiler configureForCompilerClass: nil.
 	method := self generateMethodForSelector: #methodCollectionSize:.

--- a/Druid-Tests/DruidTestInterpreter.class.st
+++ b/Druid-Tests/DruidTestInterpreter.class.st
@@ -529,6 +529,15 @@ DruidTestInterpreter >> methodWithTwoEarlyReturns [
 ]
 
 { #category : 'as yet unclassified' }
+DruidTestInterpreter >> methodWithTwoToDos [
+
+	| n |
+	n := 0.
+	1 to: 10 do: [ :i | 1 to: 10 do: [ :j | n := n + i + j ] ].
+	^ n
+]
+
+{ #category : 'as yet unclassified' }
 DruidTestInterpreter >> methodWithUnknownTypeAnnotation: aCollection [
 
 	<var: #aCollection type: #OrderedCollection>

--- a/Druid-Tests/DruidTestInterpreter.class.st
+++ b/Druid-Tests/DruidTestInterpreter.class.st
@@ -509,6 +509,15 @@ DruidTestInterpreter >> methodWithThreeNonLocalReturn [
 ]
 
 { #category : 'as yet unclassified' }
+DruidTestInterpreter >> methodWithToDo [
+
+	| n |
+	n := 0.
+	1 to: 10 do: [ :i | n := n + i ].
+	^ n
+]
+
+{ #category : 'as yet unclassified' }
 DruidTestInterpreter >> methodWithTwoEarlyReturns [
 
 	self stackTop = 0

--- a/Druid/DRAbstractInstruction.class.st
+++ b/Druid/DRAbstractInstruction.class.st
@@ -159,6 +159,12 @@ DRAbstractInstruction >> isPrimitiveFail [
 ]
 
 { #category : 'testing' }
+DRAbstractInstruction >> isScopedInstruction [
+
+	^ false
+]
+
+{ #category : 'testing' }
 DRAbstractInstruction >> isStackEffect [
 	
 	^ false

--- a/Druid/DRBlockIRGenerator.class.st
+++ b/Druid/DRBlockIRGenerator.class.st
@@ -31,7 +31,7 @@ DRBlockIRGenerator >> interpretBlockActivation: aRBBlockNode [
 { #category : 'as yet unclassified' }
 DRBlockIRGenerator >> temporariesListfrom: aNode [
 
-	^ self ir scope allTempsWithOuterTemps 
+	^ self scope allTempsWithOuterTemps 
 ]
 
 { #category : 'visiting' }

--- a/Druid/DRControlFlowGraph.class.st
+++ b/Druid/DRControlFlowGraph.class.st
@@ -371,7 +371,7 @@ DRControlFlowGraph >> createBlockView: aBlock [
 		outer;
 		right;
 		top;
-		offset: 3@(-3);
+		offset: (-2)@2;
 		move: label on: boxes.
 
 	labelBackground position: label position.

--- a/Druid/DRControlFlowGraph.class.st
+++ b/Druid/DRControlFlowGraph.class.st
@@ -48,11 +48,6 @@ DRControlFlowGraph >> addEdgeFrom: sourceBlock to: destinationBlock branchIndex:
 	^ edge
 ]
 
-{ #category : 'accessing' }
-DRControlFlowGraph >> addScopeToInstructionIfNeeded: anInstruction [
-
-]
-
 { #category : 'adding' }
 DRControlFlowGraph >> addStagedRegister: aDRStagedRegister [ 
 	

--- a/Druid/DRControlFlowGraphForTesting.class.st
+++ b/Druid/DRControlFlowGraphForTesting.class.st
@@ -15,6 +15,13 @@ Class {
 	#tag : 'IR'
 }
 
+{ #category : 'adding' }
+DRControlFlowGraphForTesting >> addScopeToInstructionIfNeeded: aDRLoadTemporaryVariable [ 
+
+	self flag: #TODO.
+	"We need to re-think the CFG for testing to apply for all the hierarchy of CFG"
+]
+
 { #category : 'accessing' }
 DRControlFlowGraphForTesting >> b0 [
 

--- a/Druid/DRExecutionStack.class.st
+++ b/Druid/DRExecutionStack.class.st
@@ -5,8 +5,9 @@ Class {
 		'stateStack',
 		'mirrorStack'
 	],
-	#category : 'Druid-Tests',
-	#package : 'Druid-Tests'
+	#category : 'Druid-CompilerCompiler',
+	#package : 'Druid',
+	#tag : 'CompilerCompiler'
 }
 
 { #category : 'merging' }
@@ -17,6 +18,12 @@ DRExecutionStack >> addTo: aDRExecutionStack [
 	stateStack withIndexDo: [ :e :i |
 		e addTo: (aDRExecutionStack frameAt: i)
 	]
+]
+
+{ #category : 'accessing' }
+DRExecutionStack >> allTemporaryInstructions [
+
+	^ (stateStack flatCollect: #temporaries) reject: #isNullValue
 ]
 
 { #category : 'accessing' }

--- a/Druid/DRExecutionState.class.st
+++ b/Druid/DRExecutionState.class.st
@@ -19,6 +19,12 @@ DRExecutionState >> addTo: aDRExecutionState [
 	executionStack addTo: aDRExecutionState executionStack
 ]
 
+{ #category : 'accessing' }
+DRExecutionState >> allTemporaryInstructions [
+
+	^ executionStack allTemporaryInstructions
+]
+
 { #category : 'stack access' }
 DRExecutionState >> baseFrame [
 	

--- a/Druid/DRFrameInfoCleaner.class.st
+++ b/Druid/DRFrameInfoCleaner.class.st
@@ -1,8 +1,9 @@
 Class {
 	#name : 'DRFrameInfoCleaner',
 	#superclass : 'DROptimisation',
-	#category : 'Druid-Tests',
-	#package : 'Druid-Tests'
+	#category : 'Druid-Optimizations',
+	#package : 'Druid',
+	#tag : 'Optimizations'
 }
 
 { #category : 'accessing' }

--- a/Druid/DRIRGenerator.class.st
+++ b/Druid/DRIRGenerator.class.st
@@ -1685,9 +1685,12 @@ DRIRGenerator >> messageSendInstructionFor: aRBMessageNode receiver: receiver ar
 	instruction := self
 		               instantiate: DRMessageSend
 		               operands: { receiver } , arguments.
-
 	instruction inlineGenerator: self inlineGenerator.
 	instruction methodNode: (method ifNotNil: [ method ast ]).
+
+	"Set the send as user to the dependecies from inner blocks"
+	instruction innerDependencies do: [ :i | i addUser: instruction ].
+	
 	^ self addInstruction: instruction from: aRBMessageNode
 ]
 

--- a/Druid/DRInline.class.st
+++ b/Druid/DRInline.class.st
@@ -71,7 +71,7 @@ DRInline >> generateInlineIRForMethods: methodsToInline of: aMessageSend [
 { #category : 'inlining' }
 DRInline >> inline: messageSend [
 
-	| methodsToInline inlinedMethodReturnValue |
+	| methodsToInline inlinedMethodReturnValue innerDependencies |
 
 	(self isIgnoredSelector: messageSend) 
 		ifTrue: [ ^ self ].
@@ -80,6 +80,9 @@ DRInline >> inline: messageSend [
 
 	methodsToInline := self methodsToInlineOf: messageSend.
 	methodsToInline ifEmpty: [ ^ self ].
+
+	"Keep the the dependecies from inner blocks to remove the message as user"
+	innerDependencies := messageSend innerDependencies.
 
 	"Break message send basic block"
 	messageSend basicBlock breakBy: messageSend.
@@ -93,6 +96,7 @@ DRInline >> inline: messageSend [
 	"Replace usages by inlines result"
 	inlineGenerator currentBasicBlock jumpTo: messageSend basicBlock successor.
 	messageSend replaceUsesBy: inlinedMethodReturnValue.
+	(innerDependencies copyWithoutAll: messageSend innerDependencies) do: [ :i | i removeUser: messageSend ].
 
 	"Remove message send block"
 	messageSend basicBlock removeFromCFGAndDisconnectSuccessors.

--- a/Druid/DRLoadArgument.class.st
+++ b/Druid/DRLoadArgument.class.st
@@ -16,6 +16,12 @@ DRLoadArgument >> acceptVisitor: aVisitor [
 ]
 
 { #category : 'accessing' }
+DRLoadArgument >> address: aDRValue [
+
+	self notYetImplemented 
+]
+
+{ #category : 'accessing' }
 DRLoadArgument >> argName [
 
 	^ argName

--- a/Druid/DRMessageSend.class.st
+++ b/Druid/DRMessageSend.class.st
@@ -22,6 +22,12 @@ DRMessageSend >> arguments [
 	^ operands allButFirst
 ]
 
+{ #category : 'accessing' }
+DRMessageSend >> dependencies [
+
+	^ super dependencies , self innerDependencies
+]
+
 { #category : 'optimizations' }
 DRMessageSend >> inline [
 	
@@ -40,6 +46,14 @@ DRMessageSend >> inlineGenerator [
 DRMessageSend >> inlineGenerator: anIrGenerator [ 
 
 	inlineGenerator := anIrGenerator
+]
+
+{ #category : 'inline' }
+DRMessageSend >> innerDependencies [
+
+	inlineGenerator ifNil: [ ^ #(  ) ].
+	^ (inlineGenerator allTemporaryInstructions reject: #isDRBlockClosure)
+		  copyWithoutAll: self operands
 ]
 
 { #category : 'accessing' }

--- a/Druid/DRMetaCompilerIRGenerator.class.st
+++ b/Druid/DRMetaCompilerIRGenerator.class.st
@@ -6,6 +6,12 @@ Class {
 	#tag : 'CompilerCompiler'
 }
 
+{ #category : 'accessing' }
+DRMetaCompilerIRGenerator >> allTemporaryInstructions [
+
+	^ #(  )
+]
+
 { #category : 'factory' }
 DRMetaCompilerIRGenerator >> createInitialBasicBlock [
 	| initialBasicBlock |

--- a/Druid/DRMethodCompilerCompiler.class.st
+++ b/Druid/DRMethodCompilerCompiler.class.st
@@ -9,12 +9,6 @@ Class {
 	#tag : 'CompilerCompiler'
 }
 
-{ #category : 'ir-generation' }
-DRMethodCompilerCompiler >> argName: index forMethod: method [
-
-	^ method argumentNames at: index
-]
-
 { #category : 'accessing' }
 DRMethodCompilerCompiler >> configureForCompilerClass: aCompilerClass [
 

--- a/Druid/DRMethodControlFlowGraph.class.st
+++ b/Druid/DRMethodControlFlowGraph.class.st
@@ -21,6 +21,35 @@ DRMethodControlFlowGraph >> addTempNameToScope: aName [
 	scope addTemps: { aName }
 ]
 
+{ #category : 'queries' }
+DRMethodControlFlowGraph >> allInstructionsWithScope: aDRScope [
+
+	^ self instructions select: [ :i |
+		  i isScopedInstruction and: [ i scope = aDRScope ] ]
+]
+
+{ #category : 'scopes' }
+DRMethodControlFlowGraph >> mergeScope: innerScope into: outerScope [
+
+	| instructions |
+	outerScope addTemps: innerScope tempVarNames.
+
+	instructions := self allInstructionsWithScope: innerScope.
+	instructions do: [ :i | i scope: outerScope ]
+]
+
+{ #category : 'scopes' }
+DRMethodControlFlowGraph >> renameTempVar: originalName from: aDRScope into: newName [
+
+	| instructions |
+	instructions := self allInstructionsWithScope: aDRScope.
+	instructions do: [ :i |
+		i address value = originalName ifTrue: [
+			i address: newName asDRValue ] ].
+
+	aDRScope renameTempVar: originalName into: newName
+]
+
 { #category : 'accessing' }
 DRMethodControlFlowGraph >> scope [
 

--- a/Druid/DRMethodIRGenerator.class.st
+++ b/Druid/DRMethodIRGenerator.class.st
@@ -234,8 +234,8 @@ DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 				         temporaryAt: aRBVariableNode name
 				         withState: executionState.
 		].
-		store ifNil: [ 1halt ].
-		store isStore ifFalse: [ 1halt ].
+"		store ifNil: [ 1halt ].
+		store isStore ifFalse: [ 1halt ]."
 		loadTemp := self
 			  addInstructionFrom: aRBVariableNode
 			  instructionKind: DRLoadTemporaryVariable
@@ -254,7 +254,6 @@ DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 		           instructionKind: DRLoadArgument
 		           operands: { aRBVariableNode variable index asDRValue }.
 	
-	1halt.
 	loadArg argName: aRBVariableNode name.
 	loadArg scope: (self scope lookupVarOrAddNewTemp: aRBVariableNode name).
 	 

--- a/Druid/DRMethodIRGenerator.class.st
+++ b/Druid/DRMethodIRGenerator.class.st
@@ -250,11 +250,12 @@ DRMethodIRGenerator >> visitArgumentVariableNode: aRBVariableNode [
 		           addInstructionFrom: aRBVariableNode
 		           instructionKind: DRLoadArgument
 		           operands: { aRBVariableNode variable index asDRValue }.
+
 	loadArg argName: aRBVariableNode name.
-
-	loadArg scope: (self ir scope lookupVar: aRBVariableNode name).
-
+	loadArg scope: (self scope lookupVarOrAddNewTemp: aRBVariableNode name).
+	 
 	^ loadArg
+
 ]
 
 { #category : 'visiting' }
@@ -277,37 +278,22 @@ DRMethodIRGenerator >> visitInstanceVariableNode: aRBVariableNode [
 { #category : 'visiting' }
 DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 
-	| loadArg |
-
-	aRBVariableNode isTempVariable ifTrue: [
-		| store loadTemp|
-		aRBVariableNode variable isEscaping ifFalse: [ 
-			store := self topFrame
-				         temporaryAt: aRBVariableNode name
-				         withState: executionState.
-		].
-"		store ifNil: [ 1halt ].
+	| store loadTemp |
+	aRBVariableNode variable isEscaping ifFalse: [
+		store := self topFrame
+			         temporaryAt: aRBVariableNode name
+			         withState: executionState ].
+	"		store ifNil: [ 1halt ].
 		store isStore ifFalse: [ 1halt ]."
-		loadTemp := self
-			  addInstructionFrom: aRBVariableNode
-			  instructionKind: DRLoadTemporaryVariable
-			  operands: {
-					  aRBVariableNode name asDRValue.
-					  store }.
-					
+	loadTemp := self
+		            addInstructionFrom: aRBVariableNode
+		            instructionKind: DRLoadTemporaryVariable
+		            operands: {
+				            aRBVariableNode name asDRValue.
+				            store }.
 
-		loadTemp scope: (self scope lookupVarOrAddNewTemp: aRBVariableNode name).
-		 ^ loadTemp.
-	].
-	"Else, it is an argument"
 
-	loadArg := self
-		           addInstructionFrom: aRBVariableNode
-		           instructionKind: DRLoadArgument
-		           operands: { aRBVariableNode variable index asDRValue }.
-	
-	loadArg argName: aRBVariableNode name.
-	loadArg scope: (self scope lookupVarOrAddNewTemp: aRBVariableNode name).
-	 
-	^ loadArg
+	loadTemp scope:
+		(self scope lookupVarOrAddNewTemp: aRBVariableNode name).
+	^ loadTemp
 ]

--- a/Druid/DRMethodIRGenerator.class.st
+++ b/Druid/DRMethodIRGenerator.class.st
@@ -13,9 +13,9 @@ DRMethodIRGenerator >> blockClosureGenerator [
 	blockGenerator := DRBlockIRGenerator new.
 	
 	blockGenerator ir scope
-		outerScope: self ir scope;
-		id: self ir scope id + 1;
-		addCopiedVarsFromOuterScope: self ir scope.
+		outerScope: self scope;
+		id: self scope id + 1;
+		addCopiedVarsFromOuterScope: self scope.
 		
 	^ blockGenerator
 ]
@@ -47,13 +47,14 @@ DRMethodIRGenerator >> initializeSpecialCases [
 { #category : 'inline' }
 DRMethodIRGenerator >> inlineGenerator [
 
-	| newIR |
-	newIR := DRMethodIRGeneratorInline new
+	| newIRGenerator |
+	newIRGenerator := DRMethodIRGeneratorInline new
 		         controlFlowGraph: controlFlowGraph;
 					typeSystem: typeSystem;
 		         yourself.
-	newIR executionState: executionState copy.
-	^ newIR
+	newIRGenerator executionState: executionState copy.
+	newIRGenerator ensureScope.
+	^ newIRGenerator
 ]
 
 { #category : 'interpreting' }
@@ -80,7 +81,8 @@ DRMethodIRGenerator >> interpretAssignmentNode: aRBAssignmentNode [
 			          operands: {
 					          aRBAssignmentNode variable name asDRValue. "Fix temporary names collisions"
 					          value }.
-		result scope: (self ir scope lookupVarOrAddNewTemp: aRBAssignmentNode variable name).
+
+		result scope: (self scope lookupVarOrAddNewTemp: aRBAssignmentNode variable name).
 		self topFrame
 			temporaryAt: aRBAssignmentNode variable name
 			put: result
@@ -90,20 +92,6 @@ DRMethodIRGenerator >> interpretAssignmentNode: aRBAssignmentNode [
 	
 
 	self unexplored
-]
-
-{ #category : 'interpreting' }
-DRMethodIRGenerator >> interpretBlockValueWith: aRBMessageNode [
-
-	| block |
-	
-	aRBMessageNode receiver acceptVisitor: self.
-	block := self popOperand simplify.
-	block isDRBlockClosure ifFalse: [
-		^ self resolveMessageSend: aRBMessageNode receiver: block ].
-	
-	
-	self interpretCode: block receiver: block
 ]
 
 { #category : 'as yet unclassified' }
@@ -194,6 +182,12 @@ DRMethodIRGenerator >> resolveMessageSend: aRBMessageNode receiver: receiver arg
 		  method: nil "Infer methods with a Type System"
 ]
 
+{ #category : 'accessing' }
+DRMethodIRGenerator >> scope [
+
+	^ self ir scope
+]
+
 { #category : 'as yet unclassified' }
 DRMethodIRGenerator >> setupCFGScope: aNode [ 
 
@@ -232,7 +226,7 @@ DRMethodIRGenerator >> visitInstanceVariableNode: aRBVariableNode [
 DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 
 	| loadArg |
-	
+
 	aRBVariableNode isTempVariable ifTrue: [
 		| store loadTemp|
 		aRBVariableNode variable isEscaping ifFalse: [ 
@@ -240,14 +234,17 @@ DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 				         temporaryAt: aRBVariableNode name
 				         withState: executionState.
 		].
-	
+		store ifNil: [ 1halt ].
+		store isStore ifFalse: [ 1halt ].
 		loadTemp := self
 			  addInstructionFrom: aRBVariableNode
 			  instructionKind: DRLoadTemporaryVariable
 			  operands: {
 					  aRBVariableNode name asDRValue.
 					  store }.
-		loadTemp scope: (self ir scope lookupVarOrAddNewTemp: aRBVariableNode name).
+					
+
+		loadTemp scope: (self scope lookupVarOrAddNewTemp: aRBVariableNode name).
 		 ^ loadTemp.
 	].
 	"Else, it is an argument"
@@ -256,10 +253,10 @@ DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 		           addInstructionFrom: aRBVariableNode
 		           instructionKind: DRLoadArgument
 		           operands: { aRBVariableNode variable index asDRValue }.
+	
+	1halt.
 	loadArg argName: aRBVariableNode name.
-	
-	
-	loadArg scope: (self ir scope lookupVarOrAddNewTemp: aRBVariableNode name).
+	loadArg scope: (self scope lookupVarOrAddNewTemp: aRBVariableNode name).
 	 
 	^ loadArg
 ]

--- a/Druid/DRMethodIRGenerator.class.st
+++ b/Druid/DRMethodIRGenerator.class.st
@@ -12,6 +12,9 @@ DRMethodIRGenerator >> blockClosureGenerator [
 	| blockGenerator |
 	blockGenerator := DRBlockIRGenerator new.
 	
+	"Review this decision..."
+	blockGenerator outerContext: self topFrame copy.
+	
 	blockGenerator ir scope
 		outerScope: self scope;
 		id: self scope id + 1;

--- a/Druid/DRMethodIRGenerator.class.st
+++ b/Druid/DRMethodIRGenerator.class.st
@@ -80,7 +80,7 @@ DRMethodIRGenerator >> interpretAssignmentNode: aRBAssignmentNode [
 			          operands: {
 					          aRBAssignmentNode variable name asDRValue. "Fix temporary names collisions"
 					          value }.
-		result scope: (self ir scope lookupVar: aRBAssignmentNode variable name).
+		result scope: (self ir scope lookupVarOrAddNewTemp: aRBAssignmentNode variable name).
 		self topFrame
 			temporaryAt: aRBAssignmentNode variable name
 			put: result
@@ -247,8 +247,7 @@ DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 			  operands: {
 					  aRBVariableNode name asDRValue.
 					  store }.
-		
-		loadTemp scope: (self ir scope lookupVar: aRBVariableNode name).
+		loadTemp scope: (self ir scope lookupVarOrAddNewTemp: aRBVariableNode name).
 		 ^ loadTemp.
 	].
 	"Else, it is an argument"
@@ -260,7 +259,7 @@ DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 	loadArg argName: aRBVariableNode name.
 	
 	
-	loadArg scope: (self ir scope lookupVar: aRBVariableNode name).
+	loadArg scope: (self ir scope lookupVarOrAddNewTemp: aRBVariableNode name).
 	 
 	^ loadArg
 ]

--- a/Druid/DRMethodIRGeneratorInline.class.st
+++ b/Druid/DRMethodIRGeneratorInline.class.st
@@ -97,7 +97,8 @@ DRMethodIRGeneratorInline >> visitTemporaryVariableNode: aRBVariableNode [
 		store := self topFrame
 			         temporaryAt: aRBVariableNode name
 			         withState: executionState.
-
+		"store isStore ifFalse: [
+			store := nil ]."
 		temp := self
 			        addInstructionFrom: aRBVariableNode
 			        instructionKind: DRLoadTemporaryVariable
@@ -106,7 +107,7 @@ DRMethodIRGeneratorInline >> visitTemporaryVariableNode: aRBVariableNode [
 					        store }.
 
 		temp scope:
-			(self ir scope lookupVarOrAddNewTemp: aRBVariableNode name).
+			(self scope lookupVarOrAddNewTemp: aRBVariableNode name).
 		^ temp ].
 
 	"Else, it is an argument"

--- a/Druid/DRMethodIRGeneratorInline.class.st
+++ b/Druid/DRMethodIRGeneratorInline.class.st
@@ -47,17 +47,21 @@ DRMethodIRGeneratorInline >> newFirstBasicBlock [
 DRMethodIRGeneratorInline >> visitTemporaryVariableNode: aRBVariableNode [
 
 	aRBVariableNode isTempVariable ifTrue: [
-		| store |
+		| store temp |
 		store := self topFrame
 			         temporaryAt: aRBVariableNode name
 			         withState: executionState.
 
-		^ self
-			  addInstructionFrom: aRBVariableNode
-			  instructionKind: DRLoadTemporaryVariable
-			  operands: {
-					  aRBVariableNode name asDRValue.
-					  store } ].
+		temp := self
+			        addInstructionFrom: aRBVariableNode
+			        instructionKind: DRLoadTemporaryVariable
+			        operands: {
+					        aRBVariableNode name asDRValue.
+					        store }.
+
+		temp scope:
+			(self ir scope lookupVarOrAddNewTemp: aRBVariableNode name).
+		^ temp ].
 
 	"Else, it is an argument"
 	(self isBaseMethodArgument: aRBVariableNode)

--- a/Druid/DRMethodIRGeneratorInline.class.st
+++ b/Druid/DRMethodIRGeneratorInline.class.st
@@ -45,16 +45,16 @@ DRMethodIRGeneratorInline >> handleCFGScope: methodNode [
 
 { #category : 'testing' }
 DRMethodIRGeneratorInline >> isBaseMethodArgument: aRBVariableNode [
-
 	"Here we check if the variable is accessing to a temporary (mainly arguments) from the compiled method.
 	This change between accessing a variable from the method to inline and from the method where it is inlined."
-	
-	| variableScope |
-	variableScope := aRBVariableNode variable scope.
-	[variableScope isMethodScope] whileFalse: [ 
-		variableScope := variableScope outerScope ].
 
-	^ executionState baseFrame method = variableScope node
+	| variableDefinitionScope |
+	variableDefinitionScope := aRBVariableNode scope.
+	[ variableDefinitionScope hasTempDefinitionFor: aRBVariableNode name ]
+		whileFalse: [
+		variableDefinitionScope := variableDefinitionScope outerScope ].
+
+	^ executionState baseFrame method = variableDefinitionScope node
 ]
 
 { #category : 'scopes' }
@@ -71,9 +71,7 @@ DRMethodIRGeneratorInline >> mergeScope [
 			from: self scope
 			into: name , suffix asString ].
 
-	self ir mergeScope: self scope into: self outerScope.
-
-	1 halt
+	self ir mergeScope: self scope into: self outerScope
 ]
 
 { #category : 'building' }

--- a/Druid/DRMethodIRGeneratorInline.class.st
+++ b/Druid/DRMethodIRGeneratorInline.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : 'DRMethodIRGeneratorInline',
 	#superclass : 'DRMethodIRGenerator',
+	#instVars : [
+		'scope'
+	],
 	#category : 'Druid-CompilerCompiler',
 	#package : 'Druid',
 	#tag : 'CompilerCompiler'
@@ -12,14 +15,26 @@ DRMethodIRGeneratorInline >> currentBasicBlock: aDRBasicBlock [
 	currentBasicBlock := aDRBasicBlock
 ]
 
+{ #category : 'scopes' }
+DRMethodIRGeneratorInline >> ensureScope [
+
+	^ scope := DRScope new
+		           outerScope: self outerScope;
+		           "id: self outerScope id + 1;"
+		           "addCopiedVarsFromOuterScope: self outerScope;"
+		           yourself
+]
+
 { #category : 'visiting' }
 DRMethodIRGeneratorInline >> finishCodeInterpretation: lastFrame [
 
 	| lastBlock |
 	lastBlock := currentBasicBlock.
 	"Non-local returns can add new returns to any frame, pop all frames to resolve them"
-	[ executionState executionStack size = 0 ] whileFalse: [ self popFrame ].
-	currentBasicBlock := lastBlock
+	[ executionState executionStack size = 0 ] whileFalse: [ self popFrameMergingDeferredReturns ].
+	currentBasicBlock := lastBlock.
+	self mergeScope
+
 ]
 
 { #category : 'accessing' }
@@ -37,10 +52,41 @@ DRMethodIRGeneratorInline >> isBaseMethodArgument: aRBVariableNode [
 	^ executionState baseFrame method = aRBVariableNode variable scope node
 ]
 
+{ #category : 'scopes' }
+DRMethodIRGeneratorInline >> mergeScope [
+
+	self assert: self scope outerScope = self outerScope.
+
+	"Rename to avoid collision"
+	self scope tempVarNames do: [ :name |
+		| suffix |
+		suffix := self outerScope tempVarNames count: [ :outerName | outerName beginsWith: name ].
+		self ir
+			renameTempVar: name
+			from: self scope
+			into: name , suffix asString ].
+
+	self ir mergeScope: self scope into: self outerScope.
+
+	1 halt
+]
+
 { #category : 'building' }
 DRMethodIRGeneratorInline >> newFirstBasicBlock [
 
 	^ self newBasicBlock
+]
+
+{ #category : 'accessing' }
+DRMethodIRGeneratorInline >> outerScope [
+
+	^ self ir scope
+]
+
+{ #category : 'accessing' }
+DRMethodIRGeneratorInline >> scope [
+
+	^ scope
 ]
 
 { #category : 'visiting' }

--- a/Druid/DRMethodIRGeneratorInline.class.st
+++ b/Druid/DRMethodIRGeneratorInline.class.st
@@ -10,6 +10,12 @@ Class {
 }
 
 { #category : 'accessing' }
+DRMethodIRGeneratorInline >> allTemporaryInstructions [
+
+	^ executionState allTemporaryInstructions
+]
+
+{ #category : 'accessing' }
 DRMethodIRGeneratorInline >> currentBasicBlock: aDRBasicBlock [
 
 	currentBasicBlock := aDRBasicBlock

--- a/Druid/DRMirrorFrame.class.st
+++ b/Druid/DRMirrorFrame.class.st
@@ -5,8 +5,9 @@ Class {
 		'deferredMethodReturns',
 		'poppedValue'
 	],
-	#category : 'Druid-Tests',
-	#package : 'Druid-Tests'
+	#category : 'Druid-CompilerBuilder',
+	#package : 'Druid',
+	#tag : 'CompilerBuilder'
 }
 
 { #category : 'adding' }

--- a/Druid/DRScope.class.st
+++ b/Druid/DRScope.class.st
@@ -103,14 +103,24 @@ DRScope >> initialize [
 { #category : 'accessing' }
 DRScope >> lookupVar: name [
 
-	| scope |
-	((tempVector includes: name) or: [argumentNames includes: name]) ifTrue: [ ^ self ].
+	^ self lookupVar: name ifNone: [ self unexplored ]
+]
 
-	scope := outerScope
-		              ifNotNil: [ :os | os lookupVar: name ]
-		              ifNil: [ "self error: 'Not explored'"]. "I need to comment this to make the inlining work"
-	
-	^ scope
+{ #category : 'accessing' }
+DRScope >> lookupVar: name ifNone: noneBlock [
+
+	((tempVector includes: name) or: [ argumentNames includes: name ])
+		ifTrue: [ ^ self ].
+
+	^ outerScope ifNotNil: [ :os | os lookupVar: name ] ifNil: [
+		  noneBlock cull: name.
+		  self ]
+]
+
+{ #category : 'accessing' }
+DRScope >> lookupVarOrAddNewTemp: name [
+
+	^ self lookupVar: name ifNone: [ self addTemps: { name } ]
 ]
 
 { #category : 'accessing' }

--- a/Druid/DRScope.class.st
+++ b/Druid/DRScope.class.st
@@ -112,9 +112,14 @@ DRScope >> lookupVar: name ifNone: noneBlock [
 	((tempVector includes: name) or: [ argumentNames includes: name ])
 		ifTrue: [ ^ self ].
 
-	^ outerScope ifNotNil: [ :os | os lookupVar: name ] ifNil: [
-		  noneBlock cull: name.
-		  self ]
+	^ outerScope
+		  ifNotNil: [ :os |
+			  os lookupVar: name ifNone: [
+				  noneBlock cull: name.
+				  ^ self ] ]
+		  ifNil: [
+			  noneBlock cull: name.
+			  self ]
 ]
 
 { #category : 'accessing' }
@@ -169,6 +174,14 @@ DRScope >> outerScope [
 DRScope >> outerScope: aScope [
 	
 	outerScope := aScope.
+]
+
+{ #category : 'modifying' }
+DRScope >> renameTempVar: oldName into: newName [
+
+	tempVector := tempVector
+		              copyReplaceAll: { oldName }
+		              with: { newName }
 ]
 
 { #category : 'accessing' }

--- a/Druid/DRStackMerger.class.st
+++ b/Druid/DRStackMerger.class.st
@@ -6,8 +6,9 @@ Class {
 		'mergeBlock',
 		'builder'
 	],
-	#category : 'Druid-Tests',
-	#package : 'Druid-Tests'
+	#category : 'Druid-CompilerBuilder',
+	#package : 'Druid',
+	#tag : 'CompilerBuilder'
 }
 
 { #category : 'accessing' }

--- a/Druid/DRTemporaryVariableInstruction.class.st
+++ b/Druid/DRTemporaryVariableInstruction.class.st
@@ -10,6 +10,18 @@ Class {
 }
 
 { #category : 'accessing' }
+DRTemporaryVariableInstruction >> address: aDRValue [
+
+	self replaceOperandAtIndex: 1 by: aDRValue
+]
+
+{ #category : 'testing' }
+DRTemporaryVariableInstruction >> isScopedInstruction [
+
+	^ true
+]
+
+{ #category : 'accessing' }
 DRTemporaryVariableInstruction >> scope [
 
 	^ scope

--- a/Druid/OCAbstractMethodScope.extension.st
+++ b/Druid/OCAbstractMethodScope.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'OCAbstractMethodScope' }
+
+{ #category : '*Druid' }
+OCAbstractMethodScope >> hasTempDefinitionFor: tempName [ 
+
+	^ self tempVarNames includes: tempName 
+]


### PR DESCRIPTION
Partially https://github.com/Alamvic/druid/issues/199

We still need to debug the bytecode tracking the push&pops.
```
label: 1
createTempVectorNamed: '0vector0' withVars: an OrderedCollection(#n #nextValue0 #nextValue1 'ssa_15' 'ssa_42' 'ssa_32' 'ssa_15' 'ssa_42')
goto: 2

label: 2
pushLiteral: 0
storeRemoteTemp: #n inVector: '0vector0'
pushLiteral: 1
popIntoRemoteTemp: #nextValue0 inVector: '0vector0'
goto: 3

label: 3
pushRemoteTemp: 'ssa_15' inVector: '0vector0'
popIntoRemoteTemp: 'ssa_15' inVector: '0vector0'
popIntoRemoteTemp: 'ssa_32' inVector: '0vector0'
pushRemoteTemp: #nextValue0 inVector: '0vector0'
pushLiteral: 10
send: #'<='
if: false goto: 10 else: 4

label: 4
goto: 5

label: 5
pushLiteral: 1
popIntoRemoteTemp: #nextValue1 inVector: '0vector0'
goto: 6

label: 6
pushRemoteTemp: 'ssa_42' inVector: '0vector0'
popIntoRemoteTemp: 'ssa_42' inVector: '0vector0'
pushRemoteTemp: #nextValue1 inVector: '0vector0'
pushLiteral: 10
send: #'<='
if: false goto: 9 else: 7

label: 7
goto: 8

label: 8
pushRemoteTemp: #n inVector: '0vector0'
pushRemoteTemp: #nextValue0 inVector: '0vector0'
send: #+
pushRemoteTemp: #nextValue1 inVector: '0vector0'
send: #+
storeRemoteTemp: #n inVector: '0vector0'
popIntoRemoteTemp: 'ssa_32' inVector: '0vector0'
pushRemoteTemp: #nextValue1 inVector: '0vector0'
pushLiteral: 1
send: #+
popIntoRemoteTemp: #nextValue1 inVector: '0vector0'
goto: 6

label: 9
pushRemoteTemp: #nextValue0 inVector: '0vector0'
pushLiteral: 1
send: #+
popIntoRemoteTemp: #nextValue0 inVector: '0vector0'
goto: 3

label: 10
goto: 11

label: 11
pushRemoteTemp: #n inVector: '0vector0'
returnTop
```