### PR TITLE
Fix multi inline

### DIFF
--- a/Druid-Opal/DRInitializeScope.class.st
+++ b/Druid-Opal/DRInitializeScope.class.st
@@ -27,7 +27,7 @@ DRInitializeScope >> acceptVisitor: aVisitor [
 DRInitializeScope >> inspectionSource: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Source'>
 	
-	^ scope node inspectionSource
+	^ scope node inspectionSource: aBuilder
 ]
 
 { #category : 'visiting' }

--- a/Druid-Opal/DRInlineMethodTest.class.st
+++ b/Druid-Opal/DRInlineMethodTest.class.st
@@ -6,6 +6,12 @@ Class {
 	#tag : 'Tests'
 }
 
+{ #category : 'asserting' }
+DRInlineMethodTest >> assert: aDRBasicBlock isDominatedBy: dominatorBlock [ 
+
+	self assert: (aDRBasicBlock isDominatedBy: dominatorBlock)
+]
+
 { #category : 'tests - type systems' }
 DRInlineMethodTest >> testImplementorsTypeSystem [
 
@@ -62,25 +68,34 @@ DRInlineMethodTest >> testInlineMethodKeepsMessageSendIfTypeIsUnknown [
 { #category : 'tests' }
 DRInlineMethodTest >> testInlineMethodWithMultiplePossibleTypesInlinesAllPossibleMethods [
 
-	| cfg |
-	self skip. "Fix multiple inlinings scopes"
-		
+	| cfg loads orderedCollection dictionary typeCheck phi |
 	cfg := self generateDruidIRFor: #methodWithMultipleTypeAnnotations:.
 	cfg applyOptimisation: DRInline new.
-	
-	self assert: cfg messageSends size equals: 4
-]
+	cfg applyOptimisation: (DRPhiSimplication then: DRDeadCodeElimination). "Clean code"
 
-{ #category : 'tests' }
-DRInlineMethodTest >> testInlineMethodWithNPossibleTypesMakesNMinus1TypeChecks [
+	self
+		denyCollection: (cfg messageSends collect: [ :send | send selector ])
+		includesAny: { #select: }.
 
-	| cfg |	
-	self skip. "Fix multiple inlinings scopes"
-		
-	cfg := self generateDruidIRFor: #methodWithMultipleTypeAnnotations:.
-	cfg applyOptimisation: DRInline new.
-	
-	self assert: (cfg allConditionalJumps count: [:jump | jump condition isTypeOf]) equals: 1
+	"Should create the type check for the guard"
+	typeCheck := cfg allConditionalJumps unique.
+	self assert: typeCheck condition isTypeOf.
+	self assert: typeCheck operand1 isLoadArgument.
+	self assert: typeCheck operand2 value isClassType.
+	self assert: typeCheck operand2 value classType equals: OrderedCollection.
+
+	"Get the collection result for both inlined cases"
+	phi := cfg phiFunctions unique.
+	loads := phi operands collect: [ :op | op simpleConstantFold ].
+	self assert: loads size equals: 2.
+	orderedCollection := loads first.
+	dictionary := loads last.
+
+	self assert: orderedCollection basicBlock isDominatedBy: typeCheck trueBranch.
+	self assert: dictionary basicBlock isDominatedBy: typeCheck falseBranch.
+
+	self assert: cfg lastBasicBlock endInstruction isReturn.
+	self assert: cfg lastBasicBlock endInstruction operand1 simpleConstantFold equals: phi
 ]
 
 { #category : 'tests' }
@@ -193,8 +208,6 @@ DRInlineMethodTest >> testProfileBasedTypeSystem_monomorphic [
 DRInlineMethodTest >> testProfileBasedTypeSystem_polimorphic [
 
 	| cfg messageSend selector typeSystem inlinedSend |
-
-	self skip. "Fix multi-inlining scopes"
 
 	compilerCompiler irGenerator typeSystem: (typeSystem := DRProfileBasedTypeSystem new).
 

--- a/Druid-Opal/DRInlineScopeTest.class.st
+++ b/Druid-Opal/DRInlineScopeTest.class.st
@@ -45,6 +45,8 @@ DRInlineScopeTest >> testInlineMethodBlock [
 	self assert: cfg scope definedTempVectors equals: {
 			('0vector0' -> #( #temp1 #temp2 )) } asOrderedDictionary.
 	self assert: cfg scope copiedVars isEmpty.
+	
+	self assert: send scope isEmpty.
 
 	self assert: inlinedMethodScope argumentNames isEmpty.
 	self assert: inlinedMethodScope tempVarNames equals: #( #tmp1 #aBlock ).
@@ -101,6 +103,8 @@ DRInlineScopeTest >> testInlineMethodBlockTwoOuterScopes [
 			('0vector0' -> #( temp block )) } asOrderedDictionary.
 	self assert: cfg scope copiedVars isEmpty.
 
+	self assert: send scope isEmpty.
+
 	self assert: inlinedScope argumentNames isEmpty.
 	self assert: inlinedScope tempVarNames equals: #( #arg ).
 	self assert: inlinedScope definedTempVectors equals: {
@@ -155,6 +159,8 @@ DRInlineScopeTest >> testInlineMethodCollisionTemporaries [
 			('0vector0' -> #( #temp1 #temp2 )) } asOrderedDictionary.
 	self assert: cfg scope copiedVars isEmpty.
 
+	self assert: send1 scope isEmpty.
+
 	self assert: inlinedMethodScope1 argumentNames isEmpty.
 	self assert: inlinedMethodScope1 tempVarNames equals: #( #tmp1 #aBlock ).
 	self assert: inlinedMethodScope1 definedTempVectors equals: {
@@ -169,6 +175,8 @@ DRInlineScopeTest >> testInlineMethodCollisionTemporaries [
 	self assert: inlinedBlockScope1 copiedVars equals: {
 			('0vector0' -> #( #temp1 #temp2 )).
 			('0vector2' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
+
+	self assert: send2 scope isEmpty.
 
 	self assert: inlinedMethodScope2 argumentNames isEmpty.
 	self assert: inlinedMethodScope2 tempVarNames equals: #( #tmp1 #aBlock ).
@@ -230,6 +238,8 @@ DRInlineScopeTest >> testInlineMultiMethods [
 	self assert: cfg scope definedTempVectors equals: {
 			('0vector0' -> #( #aCollection )) } asOrderedDictionary.
 	self assert: cfg scope copiedVars isEmpty.
+
+	self assert: send scope isEmpty.
 
 	"Inline 1"
 	self assert: inlinedMethod1Scope argumentNames isEmpty.

--- a/Druid-Opal/DRInlineScopeTest.class.st
+++ b/Druid-Opal/DRInlineScopeTest.class.st
@@ -13,24 +13,31 @@ DRInlineScopeTest >> inline: aDRMessageSend [
 ]
 
 { #category : 'tests' }
+DRInlineScopeTest >> setUp [
+
+	super setUp.
+	compilerCompiler irGenerator typeSystem: DRCustomisationTypeSystem new.
+	compilerCompiler interpreter: self inputClass new
+]
+
+{ #category : 'tests' }
 DRInlineScopeTest >> testInlineMethodBlock [
 
-	| cfg blockCFG inlinedBlockScope inlinedMethodScope |
-	compilerCompiler irGenerator typeSystem:
-		DRCustomisationTypeSystem new.
-	compilerCompiler interpreter: self inputClass new.
-
+	| cfg blockCFG inlinedBlockScope inlinedMethodScope send |
 	cfg := self generateDruidIRFor: #methodBlockNested2ReadAndWrite.
-	self inline: cfg messageSends first.
+	send := cfg messageSends first.
+	self inline: send.
 	cfg applyOptimisation: (DRCleanScopes then: DRDeadCodeElimination). "Clean a bit for quering"
 	blockCFG := cfg allBlockClosures unique ensureIR.
 
-	"Scopes: Block -> Inlined (block) -> Inlined (method) -> Method"
+	"Scopes: Block -> Inlined (block) -> Inlined (method) -> Send (empty) -> Method"
 	inlinedBlockScope := blockCFG scope outerScope.
 	inlinedMethodScope := inlinedBlockScope outerScope.
-	self assert: inlinedMethodScope outerScope equals: cfg scope.
+	self assert: inlinedMethodScope outerScope equals: send scope.
+	self assert: send scope outerScope equals: cfg scope.
 	
-	self assert: cfg scope inlinedScopes unique equals: inlinedMethodScope.
+	self assert: cfg scope inlinedScopes unique equals: send scope.
+	self assert: send scope inlinedScopes unique equals: inlinedMethodScope.
 	self assert: inlinedMethodScope inlinedScopes unique equals: inlinedBlockScope.
 	
 	self assert: cfg scope argumentNames isEmpty.
@@ -42,45 +49,43 @@ DRInlineScopeTest >> testInlineMethodBlock [
 	self assert: inlinedMethodScope argumentNames isEmpty.
 	self assert: inlinedMethodScope tempVarNames equals: #( #tmp1 #aBlock ).
 	self assert: inlinedMethodScope definedTempVectors equals: {
-			('0vector1' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
+			('0vector2' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
 	self assert: inlinedMethodScope copiedVars equals: {
 			('0vector0' -> #( #temp1 #temp2 )) } asOrderedDictionary.
 
 	self assert: inlinedBlockScope argumentNames isEmpty.
 	self assert: inlinedBlockScope tempVarNames equals: #( x ).
 	self assert: inlinedBlockScope definedTempVectors equals: {
-			('0vector2' -> #( x )) } asOrderedDictionary.
+			('0vector3' -> #( x )) } asOrderedDictionary.
 	self assert: inlinedBlockScope copiedVars equals: {
 			('0vector0' -> #( #temp1 #temp2 )).
-			('0vector1' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
+			('0vector2' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
 
 	self assert: blockCFG scope argumentNames isEmpty.
 	self assert: blockCFG scope tempVarNames equals: #( y ).
 	self assert: blockCFG scope definedTempVectors equals: {
-			('0vector3' -> #( y )) } asOrderedDictionary.
+			('0vector4' -> #( y )) } asOrderedDictionary.
 	self assert: blockCFG scope copiedVars equals: {
 			('0vector0' -> #( #temp1 #temp2 )).
-			('0vector1' -> #( #tmp1 #aBlock )).
-			('0vector2' -> #( x )) } asOrderedDictionary 
+			('0vector2' -> #( #tmp1 #aBlock )).
+			('0vector3' -> #( x )) } asOrderedDictionary 
 ]
 
 { #category : 'tests' }
 DRInlineScopeTest >> testInlineMethodBlockTwoOuterScopes [
 
-	| cfg blockCFG inlinedScope valueMessage blockScope blockReturn |
-	compilerCompiler irGenerator typeSystem:
-		DRCustomisationTypeSystem new.
-	compilerCompiler interpreter: self inputClass new.
-
+	| cfg blockCFG inlinedScope valueMessage blockScope blockReturn send |
 	cfg := self generateDruidIRFor: #methodBlockTwoOuterScopes.
-	self inline: cfg messageSends first.
+	send := cfg messageSends first.
+	self inline: send.
 	blockCFG := 	cfg allBlockClosures unique ensureIR.
 
-	"Scopes 1: Block -> Inlined -> Method"
+	"Scopes 1: Block -> Inlined -> Send (empty) -> Method"
 	blockScope := blockCFG scope.
 	inlinedScope := blockScope outerScope. 
-	self assert: cfg scope inlinedScopes first equals: inlinedScope	.
-	self assert: inlinedScope outerScope equals: cfg scope.
+	self assert: inlinedScope outerScope equals: send scope.
+	self assert: send scope outerScope equals: cfg scope.
+	self assert: cfg scope inlinedScopes first equals: send scope.
 
 	"Scopes 2: Non-inlined (empty) -> Method"
 	valueMessage := cfg messageSends unique.
@@ -99,7 +104,7 @@ DRInlineScopeTest >> testInlineMethodBlockTwoOuterScopes [
 	self assert: inlinedScope argumentNames isEmpty.
 	self assert: inlinedScope tempVarNames equals: #( #arg ).
 	self assert: inlinedScope definedTempVectors equals: {
-			('0vector1' -> #( #arg )) } asOrderedDictionary.
+			('0vector2' -> #( #arg )) } asOrderedDictionary.
 	self assert: inlinedScope copiedVars equals: {
 			('0vector0' -> #( temp block )) } asOrderedDictionary.
 
@@ -113,26 +118,34 @@ DRInlineScopeTest >> testInlineMethodBlockTwoOuterScopes [
 { #category : 'tests' }
 DRInlineScopeTest >> testInlineMethodCollisionTemporaries [
 
-	| cfg inlinedMethodScope1 inlinedBlockScope1 inlinedStores inlinedMethodScope2 inlinedBlockScope2 |
-	compilerCompiler irGenerator typeSystem:
-		DRCustomisationTypeSystem new.
-	compilerCompiler interpreter: self inputClass new.
-
+	| cfg inlinedMethodScope1 inlinedBlockScope1 inlinedStores inlinedMethodScope2 inlinedBlockScope2 send1 send2 sendScope1 sendScope2 |
 	cfg := self generateDruidIRFor: #methodBlockNested2ReadAndWrite.
-	self inline: cfg messageSends first.
-	self inline: cfg messageSends first.
+	send1 := cfg messageSends first.
+	self inline: send1.
+	send2 := cfg messageSends first.
+	self inline: send2.
 
 	self assert: cfg messageSends isEmpty.
 
-	"Scopes: Inlined (block) -> Inlined (method) -> Inlined (block) -> Inlined (method) -> Method"
-	inlinedMethodScope1 := cfg scope inlinedScopes unique.
+	"Scopes: Inlined (block) -> Inlined (method) -> Send (empty) -> Inlined (block) -> Inlined (method) -> Send (empty) -> Method"
+	sendScope1 := cfg scope inlinedScopes unique.
+	self assert: sendScope1 equals: send1 scope.
+	inlinedMethodScope1 := sendScope1 inlinedScopes unique.
+	self assert: inlinedMethodScope1 node isMethod.
 	inlinedBlockScope1 := inlinedMethodScope1 inlinedScopes unique.
-	inlinedMethodScope2 := inlinedBlockScope1 inlinedScopes unique.
+	self assert: inlinedBlockScope1 node isBlock.
+	sendScope2 := inlinedBlockScope1 inlinedScopes unique.
+	self assert: sendScope2 equals: send2 scope.
+	inlinedMethodScope2 := sendScope2 inlinedScopes unique.
+	self assert: inlinedMethodScope2 node isMethod.
 	inlinedBlockScope2 := inlinedMethodScope2 inlinedScopes unique.
+	self assert: inlinedBlockScope2 node isBlock.
 	
-	self assert: inlinedMethodScope1 outerScope equals: cfg scope.
+	self assert: sendScope1 outerScope equals: cfg scope.
+	self assert: inlinedMethodScope1 outerScope equals: sendScope1.
 	self assert: inlinedBlockScope1 outerScope equals: inlinedMethodScope1.
-	self assert: inlinedMethodScope2 outerScope equals: inlinedBlockScope1.
+	self assert: sendScope2 outerScope equals: inlinedBlockScope1.
+	self assert: inlinedMethodScope2 outerScope equals: sendScope2.
 	self assert: inlinedBlockScope2 outerScope equals: inlinedMethodScope2.
 
 	"All temps are inlined in different vectors"
@@ -145,36 +158,36 @@ DRInlineScopeTest >> testInlineMethodCollisionTemporaries [
 	self assert: inlinedMethodScope1 argumentNames isEmpty.
 	self assert: inlinedMethodScope1 tempVarNames equals: #( #tmp1 #aBlock ).
 	self assert: inlinedMethodScope1 definedTempVectors equals: {
-			('0vector1' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
+			('0vector2' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
 	self assert: inlinedMethodScope1 copiedVars equals: {
 			('0vector0' -> #( #temp1 #temp2 )) } asOrderedDictionary.
 
 	self assert: inlinedBlockScope1 argumentNames isEmpty.
 	self assert: inlinedBlockScope1 tempVarNames equals: #( x ).
 	self assert: inlinedBlockScope1 definedTempVectors equals: {
-			('0vector2' -> #( x )) } asOrderedDictionary.
+			('0vector3' -> #( x )) } asOrderedDictionary.
 	self assert: inlinedBlockScope1 copiedVars equals: {
 			('0vector0' -> #( #temp1 #temp2 )).
-			('0vector1' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
+			('0vector2' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
 
 	self assert: inlinedMethodScope2 argumentNames isEmpty.
 	self assert: inlinedMethodScope2 tempVarNames equals: #( #tmp1 #aBlock ).
 	self assert: inlinedMethodScope2 definedTempVectors equals: {
-			('0vector3' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
+			('0vector5' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
 	self assert: inlinedMethodScope2 copiedVars equals: {
 			('0vector0' -> #( #temp1 #temp2 )).
-			('0vector1' -> #( #tmp1 #aBlock )).
-			('0vector2' -> #( x )) } asOrderedDictionary.
+			('0vector2' -> #( #tmp1 #aBlock )).
+			('0vector3' -> #( x )) } asOrderedDictionary.
 
 	self assert: inlinedBlockScope2 argumentNames isEmpty.
 	self assert: inlinedBlockScope2 tempVarNames equals: #( y ).
 	self assert: inlinedBlockScope2 definedTempVectors equals: {
-			('0vector4' -> #( y )) } asOrderedDictionary.
+			('0vector6' -> #( y )) } asOrderedDictionary.
 	self assert: inlinedBlockScope2 copiedVars equals: {
 			('0vector0' -> #( #temp1 #temp2 )).
-			('0vector1' -> #( #tmp1 #aBlock )).
-			('0vector2' -> #( x )).
-			('0vector3' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
+			('0vector2' -> #( #tmp1 #aBlock )).
+			('0vector3' -> #( x )).
+			('0vector5' -> #( #tmp1 #aBlock )) } asOrderedDictionary.
 
 	"Each instruction point to the correct vector"
 	inlinedStores := cfg instructions select: [ :i |
@@ -183,4 +196,72 @@ DRInlineScopeTest >> testInlineMethodCollisionTemporaries [
 	self assert: inlinedStores size equals: 2.
 	self assert: inlinedStores first scope equals: inlinedMethodScope1.
 	self assert: inlinedStores second scope equals: inlinedMethodScope2
+]
+
+{ #category : 'tests' }
+DRInlineScopeTest >> testInlineMultiMethods [
+
+	| cfg block1CFG block2CFG inlinedMethod1Scope send inlinedMethod2Scope |
+	compilerCompiler irGenerator typeSystem: DRPragmaBasedTypeSystem new.
+	cfg := self generateDruidIRFor: #methodWithMultipleTypeAnnotations:.
+	send := cfg messageSends first.
+	self inline: send.
+	cfg applyOptimisation: (DRCleanScopes then: DRDeadCodeElimination then: DRPhiSimplication). "Clean a bit for quering"
+	block1CFG := cfg allBlockClosures second ensureIR.
+	block2CFG := cfg allBlockClosures last ensureIR.
+
+	"Scopes1: Block1 -> Inlined1 (method) -> Send (empty) -> Method"
+	inlinedMethod1Scope := block1CFG scope outerScope.
+	self assert: inlinedMethod1Scope node isMethod.
+	self assert: inlinedMethod1Scope outerScope equals: send scope.
+	self assert: send scope inlinedScopes first equals: inlinedMethod1Scope.
+
+	"Scopes2: Block2 -> Inlined2 (method) -> Send (empty) -> Method"
+	inlinedMethod2Scope := block2CFG scope outerScope.
+	self assert: inlinedMethod2Scope node isMethod.
+	self assert: inlinedMethod2Scope outerScope equals: send scope.
+	self assert: send scope inlinedScopes second equals: inlinedMethod2Scope.
+
+	self assert: send scope outerScope equals: cfg scope.
+	
+	"Variables"
+	self assert: cfg scope argumentNames equals: #(aCollection).
+	self assert: cfg scope tempVarNames isEmpty.
+	self assert: cfg scope definedTempVectors equals: {
+			('0vector0' -> #( #aCollection )) } asOrderedDictionary.
+	self assert: cfg scope copiedVars isEmpty.
+
+	"Inline 1"
+	self assert: inlinedMethod1Scope argumentNames isEmpty.
+	self assert: inlinedMethod1Scope tempVarNames equals: #( #newCollection #element #selectBlock ).
+	self assert: inlinedMethod1Scope definedTempVectors equals: {
+			('0vector2' -> #( #newCollection #element #selectBlock )) } asOrderedDictionary.
+	self assert: inlinedMethod1Scope copiedVars equals: {
+			('0vector0' -> #( #aCollection )) } asOrderedDictionary.
+
+	self assert: block1CFG scope argumentNames equals: #( index ).
+	self assert: block1CFG scope tempVarNames isEmpty.
+	self assert: block1CFG scope definedTempVectors equals: {
+			('0vector3' -> #( #index )) } asOrderedDictionary.
+	self assert: block1CFG scope copiedVars equals: {
+			('0vector0' -> #( #aCollection )).
+			('0vector2' -> #( #newCollection #element #selectBlock )) } asOrderedDictionary.
+
+	"Inline 2"
+	self assert: inlinedMethod2Scope argumentNames isEmpty.
+	self assert: inlinedMethod2Scope tempVarNames equals: #( #newCollection #aBlock ).
+	self assert: inlinedMethod2Scope definedTempVectors equals: {
+			('0vector2' -> #( #newCollection #aBlock )) } asOrderedDictionary.
+	self assert: inlinedMethod2Scope copiedVars equals: {
+			('0vector0' -> #( #aCollection )) } asOrderedDictionary.
+
+	self assert: block2CFG scope argumentNames equals: #( #each ).
+	self assert: block2CFG scope tempVarNames isEmpty.
+	self assert: block2CFG scope definedTempVectors equals: {
+			('0vector3' -> #( #each )) } asOrderedDictionary.
+	self assert: block2CFG scope copiedVars equals: {
+			('0vector0' -> #( #aCollection )).
+			('0vector2' -> #( #newCollection #aBlock )) } asOrderedDictionary.
+
+
 ]

--- a/Druid-Opal/DRMethodIRGenerator.class.st
+++ b/Druid-Opal/DRMethodIRGenerator.class.st
@@ -78,16 +78,14 @@ DRMethodIRGenerator >> initializeSpecialCases [
 { #category : 'inline' }
 DRMethodIRGenerator >> inlineGenerator [
 
-	| newIRGenerator executionStateCopy |
+	| newIRGenerator |
 	newIRGenerator := DRMethodIRGeneratorInline new
 		                  controlFlowGraph: controlFlowGraph;
 		                  typeSystem: typeSystem;
 		                  outerScope: self scope;
 		                  yourself.
 
-	executionStateCopy := executionState copy.
-	newIRGenerator executionState: executionStateCopy.
-
+	newIRGenerator executionState: executionState copy.
 	newIRGenerator generateScope.
 	^ newIRGenerator
 ]
@@ -186,7 +184,7 @@ DRMethodIRGenerator >> interpretInlinedCode: code receiver: receiver arguments: 
 	inlineGenerator := self inlineGenerator
 		                   numberOfArguments: arguments size;
 		                   yourself.
-	
+
 	"Jump to inlining block"
 	self currentBasicBlock jumpTo: inlineGenerator newBasicBlock.
 
@@ -197,7 +195,9 @@ DRMethodIRGenerator >> interpretInlinedCode: code receiver: receiver arguments: 
 
 	"Jump back and restore the state"
 	inlineGenerator currentBasicBlock jumpTo: self newBasicBlock.
-	self executionState: inlineGenerator executionState
+	self executionState: inlineGenerator executionState.
+
+	^ lastFrame
 ]
 
 { #category : 'interpreting' }

--- a/Druid-Opal/DRMethodIRGenerator.class.st
+++ b/Druid-Opal/DRMethodIRGenerator.class.st
@@ -232,6 +232,19 @@ DRMethodIRGenerator >> lookupScopeDefiningVariable: aRBVariableNode [
 	^ self scope lookupScopeDefining: aRBVariableNode variable originalVar
 ]
 
+{ #category : 'visiting' }
+DRMethodIRGenerator >> messageSendInstructionFor: aRBMessageNode receiver: receiver arguments: arguments method: method [
+
+	| instruction |
+	instruction := super
+		               messageSendInstructionFor: aRBMessageNode
+		               receiver: receiver
+		               arguments: arguments
+		               method: method.
+	instruction inlineGenerator scope node: instruction.
+	^ instruction
+]
+
 { #category : 'initialization' }
 DRMethodIRGenerator >> newCFG [
 	

--- a/Druid-Opal/DRScope.class.st
+++ b/Druid-Opal/DRScope.class.st
@@ -42,14 +42,6 @@ DRScope >> addTempVariables: variables [
 ]
 
 { #category : 'query' }
-DRScope >> allTempVarNames [
-
-	^ inlinedScopes
-		  inject: self tempVarNames
-		  into: [ :temps :scope | temps , scope allTempVarNames ]
-]
-
-{ #category : 'query' }
 DRScope >> allTempsWithOuterTemps [
 
 	^ self tempVectorVarNames , self copiedVars values flattened
@@ -125,14 +117,6 @@ DRScope >> initialize [
 DRScope >> inlinedScopes [
 
 	^ inlinedScopes
-]
-
-{ #category : 'query' }
-DRScope >> inlinedTempVectors [
-
-	^ inlinedScopes
-		  inject: OrderedDictionary new
-		  into: [ :vectors :scope | vectors , scope definedTempVectors ]
 ]
 
 { #category : 'testing' }

--- a/Druid/DRAbstractInstruction.class.st
+++ b/Druid/DRAbstractInstruction.class.st
@@ -66,7 +66,7 @@ DRAbstractInstruction >> inspectionDependencies: aBuilder [
 DRAbstractInstruction >> inspectionSource: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Source'>
 	
-	^ self originAST inspectionSourceCode
+	^ self originAST inspectionSourceCode: aBuilder
 ]
 
 { #category : 'inspecting' }

--- a/Druid/DRIRGenerator.class.st
+++ b/Druid/DRIRGenerator.class.st
@@ -1695,7 +1695,6 @@ DRIRGenerator >> messageSendInstructionFor: aRBMessageNode receiver: receiver ar
 		               instantiate: DRMessageSend
 		               operands: { receiver } , arguments.
 	instruction inlineGenerator: inlineGenerator.
-	inlineGenerator scope node: instruction.
 	instruction methodNode: (method ifNotNil: [ method ast ]).
 
 	"Set the send as user to the dependecies from inner blocks"

--- a/Druid/DRIRGenerator.class.st
+++ b/Druid/DRIRGenerator.class.st
@@ -1071,7 +1071,7 @@ DRIRGenerator >> interpretInlinedBlockBody: aRBBlockNode [
 { #category : 'special cases' }
 DRIRGenerator >> interpretInlinedCode: code receiver: receiver arguments: arguments [
 
-	self interpretCode: code receiver: receiver arguments: arguments
+	^ self interpretCode: code receiver: receiver arguments: arguments
 
 ]
 
@@ -1689,11 +1689,13 @@ DRIRGenerator >> mergeDeferredReturns: deferredMethodReturns in: aDRBasicBlock [
 { #category : 'visiting' }
 DRIRGenerator >> messageSendInstructionFor: aRBMessageNode receiver: receiver arguments: arguments method: method [
 
-	| instruction |
+	| instruction inlineGenerator |
+	inlineGenerator := self inlineGenerator.
 	instruction := self
 		               instantiate: DRMessageSend
 		               operands: { receiver } , arguments.
-	instruction inlineGenerator: self inlineGenerator.
+	instruction inlineGenerator: inlineGenerator.
+	inlineGenerator scope node: instruction.
 	instruction methodNode: (method ifNotNil: [ method ast ]).
 
 	"Set the send as user to the dependecies from inner blocks"

--- a/Druid/DRInline.class.st
+++ b/Druid/DRInline.class.st
@@ -59,9 +59,6 @@ DRInline >> generateInlineIRForMethods: methodsToInline of: aMessageSend [
 	"Last case of the guard (if any)"
 	returnValues add: (self generateInlineIRForMethod: methodsToInline last of: aMessageSend).
 
-	"The scope of the send keep empty because each inlined method create its own scope"
-	self assert: inlineGenerator scope isEmpty.
-
 	returnValues size = 1 ifTrue: [ ^ returnValues first ].
 
 	lastBlock := inlineGenerator newBasicBlock.

--- a/Druid/DRInline.class.st
+++ b/Druid/DRInline.class.st
@@ -30,7 +30,7 @@ DRInline >> generateInlineIRForMethod: classAndMethodToInline of: aMessageSend [
 
 	methodToInline := classAndMethodToInline value.
 	lastFrame := inlineGenerator
-		             interpretCode: (DRMethod methodNode: methodToInline)
+		             interpretInlinedCode: (DRMethod methodNode: methodToInline)
 		             receiver: aMessageSend operands first
 		             arguments: aMessageSend operands allButFirst.
 
@@ -52,16 +52,15 @@ DRInline >> generateInlineIRForMethods: methodsToInline of: aMessageSend [
 					         (DRTypeOf typeClass: classAndMethod key).
 					         aMessageSend receiver.
 					         classAndMethod key asDRValue }).
-		jump newTrueBranch: inlineGenerator newBasicBlock.
-		
-		"TODO: Here could be collisions between inlines"
-		self assert: inlineGenerator scope isEmpty.
-		"We should create a new scope (having the send's one as parent) per inlining"
-		
+		jump newTrueBranch: inlineGenerator newBasicBlock.		
 		returnValues add: (self generateInlineIRForMethod: classAndMethod of: aMessageSend).
 		jump newFalseBranch: inlineGenerator newBasicBlock ].
 
+	"Last case of the guard (if any)"
 	returnValues add: (self generateInlineIRForMethod: methodsToInline last of: aMessageSend).
+
+	"The scope of the send keep empty because each inlined method create its own scope"
+	self assert: inlineGenerator scope isEmpty.
 
 	returnValues size = 1 ifTrue: [ ^ returnValues first ].
 

--- a/Druid/DRMessageSend.class.st
+++ b/Druid/DRMessageSend.class.st
@@ -138,6 +138,12 @@ DRMessageSend >> sccpLatticeValueFor: sccp [
 ]
 
 { #category : 'accessing' }
+DRMessageSend >> scope [
+
+	^ inlineGenerator scope
+]
+
+{ #category : 'accessing' }
 DRMessageSend >> selector [
 
 	^ self originAST selector


### PR DESCRIPTION
Fix https://github.com/Alamvic/druid/issues/224

 scopes creation for the cases of multiple methods inlining on the same message send

Before, all inlined methods were sharing the same scope

Now, each one creates its own scope. They have as outer the same empty scope (from the send) that connects with the caller method