### PR TITLE
Dropal compiler

### DIFF
--- a/Druid-Cogit/DRCogitCanonicaliser.class.st
+++ b/Druid-Cogit/DRCogitCanonicaliser.class.st
@@ -194,6 +194,12 @@ DRCogitCanonicaliser >> visitBitOr: aDRBitOr [
 ]
 
 { #category : 'visiting' }
+DRCogitCanonicaliser >> visitBitShift: aDRBitShift [ 
+	
+	self visitLeftShift: aDRBitShift
+]
+
+{ #category : 'visiting' }
 DRCogitCanonicaliser >> visitBitXor: aDRBitXor [ 
 	
 	self sortOperandsInDoubleInstructionIfPossible: aDRBitXor 
@@ -321,7 +327,8 @@ DRCogitCanonicaliser >> visitJump: aDRJump [
 
 { #category : 'visiting' }
 DRCogitCanonicaliser >> visitLeftRotate: aDRRotate [ 
-	^ self
+	
+	"Nothing"
 ]
 
 { #category : 'visiting' }

--- a/Druid-Cogit/DRCogitCodeGenerator.class.st
+++ b/Druid-Cogit/DRCogitCodeGenerator.class.st
@@ -797,6 +797,12 @@ DRCogitCodeGenerator >> visitBitOr: aDRCogitBitAnd [
 ]
 
 { #category : 'visiting' }
+DRCogitCodeGenerator >> visitBitShift: aDRBitShift [ 
+
+	self visitLeftShift: aDRBitShift
+]
+
+{ #category : 'visiting' }
 DRCogitCodeGenerator >> visitBitXor: aDRCogitBitXor [ 
 
 	^ self threeOperandCogitRTL: #Xor instruction: aDRCogitBitXor

--- a/Druid-Cogit/DRCogitOperandSorter.class.st
+++ b/Druid-Cogit/DRCogitOperandSorter.class.st
@@ -66,6 +66,12 @@ DRCogitOperandSorter >> visitBitOr: aDRBitOr [
 ]
 
 { #category : 'visiting' }
+DRCogitOperandSorter >> visitBitShift: aDRBitShift [ 
+
+	self visitLeftShift: aDRBitShift
+]
+
+{ #category : 'visiting' }
 DRCogitOperandSorter >> visitBitXor: aDRBitXor [ 
 	
 	^ self visitCommutativeInstruction: aDRBitXor

--- a/Druid-Cogit/DRJITCompileTimeExpressionGenerator.class.st
+++ b/Druid-Cogit/DRJITCompileTimeExpressionGenerator.class.st
@@ -86,7 +86,7 @@ DRJITCompileTimeExpressionGenerator >> visitBitAnd: aDRBitAnd [
 { #category : 'visiting' }
 DRJITCompileTimeExpressionGenerator >> visitBitShift: aDRBitShift [ 
 	
-	self visitLeftShift: aDRBitShift
+	^ self visitLeftShift: aDRBitShift
 ]
 
 { #category : 'visiting' }

--- a/Druid-Cogit/DRJITCompileTimeExpressionGenerator.class.st
+++ b/Druid-Cogit/DRJITCompileTimeExpressionGenerator.class.st
@@ -84,6 +84,12 @@ DRJITCompileTimeExpressionGenerator >> visitBitAnd: aDRBitAnd [
 ]
 
 { #category : 'visiting' }
+DRJITCompileTimeExpressionGenerator >> visitBitShift: aDRBitShift [ 
+	
+	self visitLeftShift: aDRBitShift
+]
+
+{ #category : 'visiting' }
 DRJITCompileTimeExpressionGenerator >> visitBranchIfCondition: aDRBranchIfCondition [
 
 	^ aDRBranchIfCondition condition acceptVisitor: self withBranch: aDRBranchIfCondition

--- a/Druid-Opal/DRBytecodeBlockGenerator.class.st
+++ b/Druid-Opal/DRBytecodeBlockGenerator.class.st
@@ -55,7 +55,7 @@ DRBytecodeBlockGenerator >> visitBlockReturn: aDBlockRReturn [
 { #category : 'ir-to-target' }
 DRBytecodeBlockGenerator >> visitReturn: aDRReturn [ 
 
-	blockScope isInlined ifTrue: [ 
+	blockScope wasMethodInlined ifTrue: [ 
 		Error signal: 'Non-local return on inlined method breaks the semantics' ].
 
 	super visitReturn: aDRReturn

--- a/Druid-Opal/DRBytecodeGenerator.class.st
+++ b/Druid-Opal/DRBytecodeGenerator.class.st
@@ -166,6 +166,12 @@ DRBytecodeGenerator >> visitBitAnd: aDRBitAnd [
 	self sendMessage: #bitAnd: fromInstruction: aDRBitAnd 
 ]
 
+{ #category : 'visiting' }
+DRBytecodeGenerator >> visitBitOr: aDRBitOr [ 
+
+		self sendMessage: #bitOr: fromInstruction: aDRBitOr 
+]
+
 { #category : 'ir-to-target' }
 DRBytecodeGenerator >> visitBlock: aDRBasicBlock [
 
@@ -239,6 +245,12 @@ DRBytecodeGenerator >> visitCopy: aDRCopy [
 	aDRCopy operand1 acceptVisitor: self
 ]
 
+{ #category : 'visiting' }
+DRBytecodeGenerator >> visitDivision: aDRDivision [ 
+
+		self sendMessage: #/ fromInstruction: aDRDivision 
+]
+
 { #category : 'ir-to-target' }
 DRBytecodeGenerator >> visitEqualsThan: aDREqualsThanComparison inBranch: aDRBranchIfCondition [
 
@@ -249,6 +261,12 @@ DRBytecodeGenerator >> visitEqualsThan: aDREqualsThanComparison inBranch: aDRBra
 DRBytecodeGenerator >> visitGetConditionCode: aDRGetConditionCode [ 
 
 	aDRGetConditionCode condition acceptVisitor: self withBranch: aDRGetConditionCode
+]
+
+{ #category : 'visiting' }
+DRBytecodeGenerator >> visitGreaterOrEqualsThan: aDRGreaterOrEqualsThanComparison inBranch: aDRBranch [
+
+	self sendMessage: #'>=' fromInstruction: aDRBranch
 ]
 
 { #category : 'visiting' }
@@ -324,6 +342,12 @@ DRBytecodeGenerator >> visitLoadLiteralVariable: aDRLoadLiteralVariable [
 DRBytecodeGenerator >> visitMessageSend: aDRMessageSend [ 
 
 	self sendMessage: aDRMessageSend selector fromInstruction: aDRMessageSend
+]
+
+{ #category : 'ir-to-target' }
+DRBytecodeGenerator >> visitMod: aDRMod [
+
+	self sendMessage: #\\ fromInstruction: aDRMod
 ]
 
 { #category : 'ir-to-target' }

--- a/Druid-Opal/DRBytecodeGenerator.class.st
+++ b/Druid-Opal/DRBytecodeGenerator.class.st
@@ -172,6 +172,12 @@ DRBytecodeGenerator >> visitBitOr: aDRBitOr [
 		self sendMessage: #bitOr: fromInstruction: aDRBitOr 
 ]
 
+{ #category : 'visiting' }
+DRBytecodeGenerator >> visitBitShift: aDRBitShift [ 
+
+	self sendMessage: #bitShift: fromInstruction: aDRBitShift 
+]
+
 { #category : 'ir-to-target' }
 DRBytecodeGenerator >> visitBlock: aDRBasicBlock [
 

--- a/Druid-Opal/DRBytecodeGenerator.class.st
+++ b/Druid-Opal/DRBytecodeGenerator.class.st
@@ -253,8 +253,10 @@ DRBytecodeGenerator >> visitCopy: aDRCopy [
 
 { #category : 'visiting' }
 DRBytecodeGenerator >> visitDivision: aDRDivision [ 
-
-		self sendMessage: #/ fromInstruction: aDRDivision 
+	"TODO: / and // are compiled as this instruction"
+	| selector |
+	selector := 	aDRDivision originAST ifNotNil: [ :ast | ast selector ] ifNil: [ #/ ].
+	self sendMessage: selector fromInstruction: aDRDivision 
 ]
 
 { #category : 'ir-to-target' }

--- a/Druid-Opal/DRBytecodeGenerator.class.st
+++ b/Druid-Opal/DRBytecodeGenerator.class.st
@@ -160,6 +160,12 @@ DRBytecodeGenerator >> visitArrayNode: aDRArrayNode [
 	builder pushConsArray: aDRArrayNode operands size
 ]
 
+{ #category : 'visiting' }
+DRBytecodeGenerator >> visitBitAnd: aDRBitAnd [ 
+
+	self sendMessage: #bitAnd: fromInstruction: aDRBitAnd 
+]
+
 { #category : 'ir-to-target' }
 DRBytecodeGenerator >> visitBlock: aDRBasicBlock [
 

--- a/Druid-Opal/DRBytecodeGenerator.class.st
+++ b/Druid-Opal/DRBytecodeGenerator.class.st
@@ -403,7 +403,7 @@ DRBytecodeGenerator >> visitStoreInstVar: aDRStoreInstanceVariable [
 	(self isSelf: aDRStoreInstanceVariable operand1) ifTrue: [
 		aDRStoreInstanceVariable operand3 acceptVisitor: self.
 		builder storeInstVar: aDRStoreInstanceVariable operand2 value.
-		aDRStoreInstanceVariable users size = 0 ifTrue: [ 
+		aDRStoreInstanceVariable users isEmpty ifTrue: [ 
 			builder popTop.
 		].
 		^ self 

--- a/Druid-Opal/DRBytecodeGeneratorTest.class.st
+++ b/Druid-Opal/DRBytecodeGeneratorTest.class.st
@@ -585,7 +585,7 @@ DRBytecodeGeneratorTest >> testMethodWritingClassVariable [
 DRBytecodeGeneratorTest >> testOpalExamples [
 
 	| ignoredProtocols |
-	ignoredProtocols := #( #'examples - pragmas' #'examples - blocks-optimized' ).
+	ignoredProtocols := #( #'examples - pragmas' ).
 
 	OCOpalExamples methods
 		reject: [ :opalMethod |

--- a/Druid-Opal/DRBytecodeGeneratorTest.class.st
+++ b/Druid-Opal/DRBytecodeGeneratorTest.class.st
@@ -212,6 +212,12 @@ DRBytecodeGeneratorTest >> testCreateTempVectorInsideLoop [
 ]
 
 { #category : 'tests' }
+DRBytecodeGeneratorTest >> testMethodAssignmentExpression [
+
+	self assertCompilationFor: #methodWithAssignmentExpression fromClass: DrOpalExamples
+]
+
+{ #category : 'tests' }
 DRBytecodeGeneratorTest >> testMethodEmpty [
 
 	self assertCompilationFor: #exampleEmptyMethod fromClass: OCOpalExamples

--- a/Druid-Opal/DRInstructionsTest.class.st
+++ b/Druid-Opal/DRInstructionsTest.class.st
@@ -1,8 +1,8 @@
 Class {
 	#name : 'DRInstructionsTest',
 	#superclass : 'DRIRTest',
-	#category : 'Druid-Tests',
-	#package : 'Druid-Tests'
+	#category : 'Druid-Opal',
+	#package : 'Druid-Opal'
 }
 
 { #category : 'test' }

--- a/Druid-Opal/DRInstructionsTest.class.st
+++ b/Druid-Opal/DRInstructionsTest.class.st
@@ -62,8 +62,8 @@ DRInstructionsTest >> testReplaceMessageSendUpdateInnerDependencies [
 	| cfg instruction message newInstruction |
 	cfg := self generateDruidIRFor: #simpleMethodWithBlockReadingOuterVariable.
 	cfg applyOptimisation: DRCleanControlFlow new.
-	instruction := cfg firstBasicBlock instructions third.
-	message := cfg firstBasicBlock instructions fourth.
+	instruction := cfg firstBasicBlock instructions fourth.
+	message := cfg firstBasicBlock instructions fifth.
 	 
 	self assert: (instruction users includes: message).
 

--- a/Druid-Opal/DRMethodIRGenerator.class.st
+++ b/Druid-Opal/DRMethodIRGenerator.class.st
@@ -6,6 +6,30 @@ Class {
 	#tag : 'Compiler'
 }
 
+{ #category : 'adding' }
+DRMethodIRGenerator >> addAssignmentInstructionFrom: anAssignmentNode instructionKind: aClass operands: operands [
+
+	| store load scope |
+	store := self
+		         addInstructionWithNoResultFrom: anAssignmentNode
+		         instructionKind: aClass
+		         operands: operands.
+
+	self popOperand.
+
+	load := self
+		        addInstructionFrom: anAssignmentNode variable
+		        instructionKind: aClass loadInstructionKind
+		        operands: operands allButLast.
+
+	store isScopedInstruction ifTrue: [
+		scope := self lookupScopeDefiningVariable: anAssignmentNode variable.
+		store scope: scope.
+		load scope: scope ].
+
+	^ load
+]
+
 { #category : 'building' }
 DRMethodIRGenerator >> blockClosureFor: aRBBlockNode [
 
@@ -104,7 +128,7 @@ DRMethodIRGenerator >> interpretAssignmentNode: aRBAssignmentNode [
 
 	aRBAssignmentNode variable binding isInstanceVariable ifTrue: [
 		^ self
-			  addInstructionWithNoResultFrom: aRBAssignmentNode
+			  addAssignmentInstructionFrom: aRBAssignmentNode
 			  instructionKind: DRStoreInstanceVariable
 			  operands: {
 					  self receiver.
@@ -113,7 +137,7 @@ DRMethodIRGenerator >> interpretAssignmentNode: aRBAssignmentNode [
 
 	aRBAssignmentNode variable binding isClassVariable ifTrue: [
 		^ self
-			  addInstructionWithNoResultFrom: aRBAssignmentNode
+			  addAssignmentInstructionFrom: aRBAssignmentNode
 			  instructionKind: DRStoreLiteralVariable
 			  operands: {
 					  aRBAssignmentNode variable binding asDRValue.
@@ -123,14 +147,11 @@ DRMethodIRGenerator >> interpretAssignmentNode: aRBAssignmentNode [
 		ifTrue: [
 			| result |
 			result := self
-				          addInstructionWithNoResultFrom: aRBAssignmentNode
+				          addAssignmentInstructionFrom: aRBAssignmentNode
 				          instructionKind: DRStoreTemporaryVariable
 				          operands: {
 						          aRBAssignmentNode variable name asDRValue.
 						          value }.
-
-			result scope:
-				(self lookupScopeDefiningVariable: aRBAssignmentNode variable).
 
 			(self hasTemporary: aRBAssignmentNode variable name) ifTrue: [
 				self topFrame

--- a/Druid-Opal/DRMethodIRGenerator.class.st
+++ b/Druid-Opal/DRMethodIRGenerator.class.st
@@ -101,6 +101,8 @@ DRMethodIRGenerator >> initializeSpecialCases [
 
 	super initializeSpecialCases.
 
+	specialCases at: #bitShift: put: #interpretBitShiftWith:.
+
 	specialCases at: #sendingMessageTo: put: #ignoreMessageWith:.
 
 ]

--- a/Druid-Opal/DRMethodIRGenerator.class.st
+++ b/Druid-Opal/DRMethodIRGenerator.class.st
@@ -263,9 +263,10 @@ DRMethodIRGenerator >> interpretWhileTrueWith: aRBMessageNode [
 
 	| receiver |
 	(aRBMessageNode receiver isBlock and: [
-		 aRBMessageNode arguments first isBlock ]) ifTrue: [
+			 aRBMessageNode selector numArgs = 0 or: [
+				 aRBMessageNode arguments first isBlock ] ]) ifTrue: [
 		^ super interpretWhileTrueWith: aRBMessageNode ].
-	
+
 	"Resolve it as a normal send"
 	receiver := self visitOperand: aRBMessageNode receiver.
 	^ self resolveMessageSend: aRBMessageNode receiver: receiver

--- a/Druid-Opal/DRMethodIRGenerator.class.st
+++ b/Druid-Opal/DRMethodIRGenerator.class.st
@@ -460,17 +460,7 @@ DRMethodIRGenerator >> visitInstanceVariableNode: aRBVariableNode [
 { #category : 'visiting' }
 DRMethodIRGenerator >> visitTemporaryVariableNode: aRBVariableNode [
 
-	| store loadTemp |
-
-	"If the variable is in the current frame, then reuse directly the instruction"
-	(self hasTemporary: aRBVariableNode name) ifTrue: [
-		store := self topFrame
-			         temporaryAt: aRBVariableNode name
-			         withState: executionState ].
-	
-	^ self interpretTemporaryVariable: aRBVariableNode.
-	
-
+	^ self interpretTemporaryVariable: aRBVariableNode
 ]
 
 { #category : 'visiting' }

--- a/Druid-Opal/DROpalCompiler.class.st
+++ b/Druid-Opal/DROpalCompiler.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : 'DROpalCompiler',
+	#superclass : 'Object',
+	#classInstVars : [
+		'bytecodeGenerator'
+	],
+	#category : 'Druid-Opal-Objects',
+	#package : 'Druid-Opal',
+	#tag : 'Objects'
+}
+
+{ #category : 'utilities' }
+DROpalCompiler class >> generateMethodFromCFG: aDRControlFlowGraph withSelector: selector numArgs: numArgs [
+	
+	aDRControlFlowGraph applyOptimisation: DRFrameInfoCleaner new.
+	aDRControlFlowGraph applyOptimisation: DRBranchCollapse new.
+	
+	aDRControlFlowGraph applyOptimisation: DRPhiSimplication new.
+	aDRControlFlowGraph applyOptimisation: (DRSCCP then: DRDeadCodeElimination).
+
+	DRUnconditionalBackJumpScheluder new applyTo: aDRControlFlowGraph.
+	DRLocalVariableInstructionScheluder new applyTo: aDRControlFlowGraph.
+	aDRControlFlowGraph applyOptimisation: DRCleanScopes new.
+	aDRControlFlowGraph applyOptimisation: DRDeadCodeElimination new.
+
+	bytecodeGenerator numArgs: numArgs.
+	bytecodeGenerator methodName: selector.
+	bytecodeGenerator generateTargetASTFromIR: aDRControlFlowGraph methodName: selector.
+	^ bytecodeGenerator targetAST
+]
+
+{ #category : 'recompilation' }
+DROpalCompiler class >> recompile: selector from: oldClass [
+
+	| compilerCompiler oldMethod cfg newMethod typeSystem newSelector |
+	compilerCompiler := DRMethodCompilerCompiler new.
+	typeSystem := DRCustomisationTypeSystem new.
+	bytecodeGenerator := DRBytecodeGenerator new.
+
+	oldMethod := oldClass >> selector.
+	compilerCompiler configureForCompilerClass: nil.
+	compilerCompiler interpreter: oldClass basicNew.
+	compilerCompiler irGenerator typeSystem: typeSystem.
+
+	cfg := compilerCompiler generateDruidIRFor: oldMethod.
+	compilerCompiler optimize: cfg.
+	compilerCompiler optimize: cfg.
+
+	newSelector := #dr , selector.
+	newMethod := self generateMethodFromCFG: cfg withSelector: newSelector numArgs: oldMethod numArgs.
+
+	oldClass addSelector: newSelector withMethod: newMethod 
+]

--- a/Druid-Opal/DROpalCompiler.class.st
+++ b/Druid-Opal/DROpalCompiler.class.st
@@ -9,6 +9,14 @@ Class {
 	#tag : 'Objects'
 }
 
+{ #category : 'as yet unclassified' }
+DROpalCompiler class >> copyMethod: selector from: aClass to: newClass [
+
+	| method |
+	method := aClass >> selector.
+	newClass addSelector: selector withMethod: method copy
+]
+
 { #category : 'utilities' }
 DROpalCompiler class >> generateMethodFromCFG: aDRControlFlowGraph withSelector: selector numArgs: numArgs [
 	
@@ -61,7 +69,13 @@ DROpalCompiler class >> recompile: selector from: oldClass to: newClass [
 { #category : 'as yet unclassified' }
 DROpalCompiler class >> recompileClass: aClass [ 
 	
-	| oldName _superclass slots packageName newName tag newClass |
+	self recompileClass: aClass except: #()
+]
+
+{ #category : 'as yet unclassified' }
+DROpalCompiler class >> recompileClass: aClass except: ignoredSelectors [
+	
+	| oldName _superclass slots packageName newName tag newClass n |
 	oldName := aClass name.
 	_superclass := aClass superclass.
 	slots := aClass slots collect: [ :slot | slot name ].
@@ -75,8 +89,17 @@ DROpalCompiler class >> recompileClass: aClass [
 		package: packageName;
 		install.
 		
-	aClass selectors do: [ :sel |
-		self recompile: sel from: aClass to: newClass ].
+	n := 0.	
 		
+	aClass selectors do: [ :sel |
+		[ self recompile: sel from: aClass to: newClass ]
+		on: Error do: [ :ex |
+			n := n + 1.
+			n trace. '. ' trace.
+			sel traceCr.
+			ex description traceCr.
+			self copyMethod: sel from: aClass to: newClass
+		]
+	].		
 	^ newClass
 ]

--- a/Druid-Opal/DROpalCompiler.class.st
+++ b/Druid-Opal/DROpalCompiler.class.st
@@ -81,8 +81,10 @@ DROpalCompiler class >> recompileClass: aClass except: ignoredSelectors [
 	slots := aClass slots collect: [ :slot | slot name ].
 	tag := aClass packageTag.
 	packageName := aClass package name.
-	
 	newName := #DR , oldName.
+
+	self removeClassIfNeeded: newName.
+
 	newClass := _superclass << newName 
 		slots: slots;
 		tag: tag;
@@ -102,4 +104,11 @@ DROpalCompiler class >> recompileClass: aClass except: ignoredSelectors [
 		]
 	].		
 	^ newClass
+]
+
+{ #category : 'removing' }
+DROpalCompiler class >> removeClassIfNeeded: newName [
+
+	(Smalltalk systemNavigation environment classNamed: newName)
+		ifNotNil: [ :class | Smalltalk systemNavigation removeClass: class ]
 ]

--- a/Druid-Opal/DROpalCompiler.class.st
+++ b/Druid-Opal/DROpalCompiler.class.st
@@ -31,6 +31,12 @@ DROpalCompiler class >> generateMethodFromCFG: aDRControlFlowGraph withSelector:
 
 { #category : 'recompilation' }
 DROpalCompiler class >> recompile: selector from: oldClass [
+	
+	^ self recompile: selector from: oldClass to: oldClass 
+]
+
+{ #category : 'recompilation' }
+DROpalCompiler class >> recompile: selector from: oldClass to: newClass [
 
 	| compilerCompiler oldMethod cfg newMethod typeSystem newSelector |
 	compilerCompiler := DRMethodCompilerCompiler new.
@@ -46,8 +52,31 @@ DROpalCompiler class >> recompile: selector from: oldClass [
 	compilerCompiler optimize: cfg.
 	compilerCompiler optimize: cfg.
 
-	newSelector := #dr , selector.
+	newSelector := "#dr ," selector.
 	newMethod := self generateMethodFromCFG: cfg withSelector: newSelector numArgs: oldMethod numArgs.
 
-	oldClass addSelector: newSelector withMethod: newMethod 
+	^ newClass addSelector: newSelector withMethod: newMethod 
+]
+
+{ #category : 'as yet unclassified' }
+DROpalCompiler class >> recompileClass: aClass [ 
+	
+	| oldName _superclass slots packageName newName tag newClass |
+	oldName := aClass name.
+	_superclass := aClass superclass.
+	slots := aClass slots collect: [ :slot | slot name ].
+	tag := aClass packageTag.
+	packageName := aClass package name.
+	
+	newName := #DR , oldName.
+	newClass := _superclass << newName 
+		slots: slots;
+		tag: tag;
+		package: packageName;
+		install.
+		
+	aClass selectors do: [ :sel |
+		self recompile: sel from: aClass to: newClass ].
+		
+	^ newClass
 ]

--- a/Druid-Opal/DROpalCompiler.class.st
+++ b/Druid-Opal/DROpalCompiler.class.st
@@ -93,7 +93,8 @@ DROpalCompiler class >> recompileClass: aClass except: ignoredSelectors [
 		
 	n := 0.	
 		
-	aClass selectors do: [ :sel |
+	(aClass selectors copyWithoutAll: ignoredSelectors)
+	do: [ :sel |
 		[ self recompile: sel from: aClass to: newClass ]
 		on: Error do: [ :ex |
 			n := n + 1.
@@ -102,7 +103,14 @@ DROpalCompiler class >> recompileClass: aClass except: ignoredSelectors [
 			ex description traceCr.
 			self copyMethod: sel from: aClass to: newClass
 		]
-	].		
+	].
+
+	ignoredSelectors do: [ :sel | 
+		self copyMethod: sel from: aClass to: newClass ].
+	
+	aClass class selectors do: [ :sel |
+		self copyMethod: sel from: aClass class to: newClass class ].
+		
 	^ newClass
 ]
 

--- a/Druid-Opal/DRScope.class.st
+++ b/Druid-Opal/DRScope.class.st
@@ -139,17 +139,6 @@ DRScope >> isEmpty [
 	^ true
 ]
 
-{ #category : 'testing' }
-DRScope >> isInlined [
-
-	outerScope ifNil: [ ^ false ].
-	node isMethod ifFalse: [ ^ outerScope isInlined ].
-	
-	"If we arrive to a method scope and it's not the last one, it was inlined"
-	self assert: outerScope node isMessageSend.
-	^ true
-]
-
 { #category : 'query' }
 DRScope >> lookupScopeDefining: aVariable [
 
@@ -213,4 +202,15 @@ DRScope >> tempVectorName [
 DRScope >> tempVectorVarNames [ 
 	
 	^ (self argumentNames , self tempVarNames) asArray 
+]
+
+{ #category : 'testing' }
+DRScope >> wasMethodInlined [
+
+	outerScope ifNil: [ ^ false ].
+	node isMethod ifFalse: [ ^ outerScope wasMethodInlined ].
+	
+	"If we arrive to a method scope and it's not the last one, it was inlined"
+	self assert: outerScope node isMessageSend.
+	^ true
 ]

--- a/Druid-Opal/DrOpalExamples.class.st
+++ b/Druid-Opal/DrOpalExamples.class.st
@@ -2,7 +2,9 @@ Class {
 	#name : 'DrOpalExamples',
 	#superclass : 'Object',
 	#instVars : [
-		'dummyVariable'
+		'dummyVariable',
+		'fillMask',
+		'ncol'
 	],
 	#classVars : [
 		'classVariable'
@@ -323,6 +325,15 @@ DrOpalExamples >> methodReadingClassVariable [
 DrOpalExamples >> methodWithArg: aCollection [
 	<var: #aCollection type: #OrderedCollection>
 	^ aCollection select: [ :element | element even ]
+]
+
+{ #category : 'as yet unclassified' }
+DrOpalExamples >> methodWithAssignmentExpression [
+
+	| irow |
+	dummyVariable := #(1 2 3).
+	irow := 0.
+	dummyVariable at: (irow := irow + 1)
 ]
 
 { #category : 'as yet unclassified' }

--- a/Druid/DRAbstractInstruction.class.st
+++ b/Druid/DRAbstractInstruction.class.st
@@ -66,7 +66,7 @@ DRAbstractInstruction >> inspectionDependencies: aBuilder [
 DRAbstractInstruction >> inspectionSource: aBuilder [
 	<inspectorPresentationOrder: 0 title: 'Source'>
 	
-	^ self originAST inspectionSourceCode: aBuilder
+	^ self originAST inspectionSource: aBuilder
 ]
 
 { #category : 'inspecting' }

--- a/Druid/DRBitAnd.class.st
+++ b/Druid/DRBitAnd.class.st
@@ -44,5 +44,5 @@ DRBitAnd >> sccpOperateOnLattice: operand and: operand2 [
 { #category : 'types' }
 DRBitAnd >> typeWithAlreadySeen: aCollection [
 
-	^ DRUnsignedIntegerType size: 8 "bytes per word"
+	^ DRUnsignedIntegerType bits64
 ]

--- a/Druid/DRBlockClosure.class.st
+++ b/Druid/DRBlockClosure.class.st
@@ -158,5 +158,5 @@ DRBlockClosure >> sccpLatticeValueFor: sccp [
 { #category : 'activation' }
 DRBlockClosure >> typeWithAlreadySeen: aCollection [
 
-	self error: 'Not implemented yet'
+	^ BlockClosure asDRType 
 ]

--- a/Druid/DRBlockClosure.class.st
+++ b/Druid/DRBlockClosure.class.st
@@ -154,3 +154,9 @@ DRBlockClosure >> sccpLatticeValueFor: sccp [
 	"This instruction has no value"
 	^ sccp bottom
 ]
+
+{ #category : 'activation' }
+DRBlockClosure >> typeWithAlreadySeen: aCollection [
+
+	self error: 'Not implemented yet'
+]

--- a/Druid/DRCall.class.st
+++ b/Druid/DRCall.class.st
@@ -111,3 +111,9 @@ DRCall >> shouldSaveLinkReg [
 
 	^ shouldSaveLinkReg
 ]
+
+{ #category : 'types' }
+DRCall >> typeWithAlreadySeen: aCollection [
+
+	^ DRVoidType new
+]

--- a/Druid/DRClosureCreation.class.st
+++ b/Druid/DRClosureCreation.class.st
@@ -36,3 +36,9 @@ DRClosureCreation >> sccpLatticeValueFor: sccp [
 	"This instruction has no value"
 	^ sccp bottom
 ]
+
+{ #category : 'types' }
+DRClosureCreation >> typeWithAlreadySeen: aCollection [ 
+
+	^ DRVoidType new
+]

--- a/Druid/DRConstantValue.class.st
+++ b/Druid/DRConstantValue.class.st
@@ -144,7 +144,7 @@ DRConstantValue >> typeWithAlreadySeen: aCollection [
 	value isInteger ifTrue: [ ^ DRSignedIntegerType size: 8 "Word size" ].
 	value isFloat ifTrue: [ ^ DRFloatType new ].
 	value isGlobalVariable ifTrue: [ ^ value value class asDRType ].
-	^ value class
+	^ value class asDRType 
 ]
 
 { #category : 'accessing' }

--- a/Druid/DRDeoptimize.class.st
+++ b/Druid/DRDeoptimize.class.st
@@ -30,3 +30,9 @@ DRDeoptimize >> sccpEvaluateFor: sccp [
 
 	"Nothing to do"
 ]
+
+{ #category : 'types' }
+DRDeoptimize >> typeWithAlreadySeen: aCollection [ 
+
+	^ DRVoidType new
+]

--- a/Druid/DRFloatToInt.class.st
+++ b/Druid/DRFloatToInt.class.st
@@ -33,3 +33,9 @@ DRFloatToInt >> simpleConstantFold [
 	
 	^ self operand1 simpleConstantFold asInteger
 ]
+
+{ #category : 'types' }
+DRFloatToInt >> typeWithAlreadySeen: aCollection [
+
+	^ DRSignedIntegerType bits64
+]

--- a/Druid/DRGetFloatBits.class.st
+++ b/Druid/DRGetFloatBits.class.st
@@ -35,3 +35,9 @@ DRGetFloatBits >> simpleConstantFold [
 	folded isNumber ifTrue: [ ^ folded asIEEE64BitWord ].
 	^ folded
 ]
+
+{ #category : 'types' }
+DRGetFloatBits >> typeWithAlreadySeen: aCollection [ 
+
+	^ DRUnsignedIntegerType bits64
+]

--- a/Druid/DRIRGenerator.class.st
+++ b/Druid/DRIRGenerator.class.st
@@ -410,6 +410,8 @@ DRIRGenerator >> initializeSpecialCases [
 	specialCases at: #ifTrue: put: #interpretIfTrueWith:.
 	specialCases at: #whileTrue put: #interpretWhileTrueWith:.
 	specialCases at: #whileTrue: put: #interpretWhileTrueWith:.
+	specialCases at: #whileFalse put: #interpretWhileTrueWith:.
+	specialCases at: #whileFalse: put: #interpretWhileTrueWith:.
 	specialCases at: #caseOf:otherwise: put: #interpretCaseOfWith:.
 	specialCases at: #cppIf:ifTrue: put: #interpretCppIfWith:.
 	specialCases at: #cppIf:ifTrue:ifFalse: put: #interpretCppIfWith:.
@@ -485,6 +487,7 @@ DRIRGenerator >> initializeSpecialCases [
 	specialCases at: #bitXor: put: #interpretBitXorWith:.
 	specialCases at: #anyMask: put: #interpretAnyMaskWith:.
 	specialCases at: #rotateLeft:by: put: #interpretRotateLeftBy:.
+	specialCases at: #bitShift: put: #interpretBitShiftWith:.
 		
 	"special simulation cases"
 	specialCases at: #cCode: put: #interpretCCodeInSmalltalkWith:.
@@ -1595,7 +1598,7 @@ DRIRGenerator >> interpretValue: anOCLiteralValueNode [
 { #category : 'special cases' }
 DRIRGenerator >> interpretWhileTrueWith: aRBMessageNode [
 
-	| trueBranchBasicBlockOut conditionalJump conditionEntryBlock executionStateAtEntry |
+	| trueBranchBasicBlockOut conditionalJump conditionEntryBlock executionStateAtEntry bool |
 	"Compile
 	
 	[ condition ] whileTrue: [ something ]
@@ -1631,13 +1634,14 @@ DRIRGenerator >> interpretWhileTrueWith: aRBMessageNode [
 		self notYetImplemented ].
 
 	"The conditional jump"
+	bool := aRBMessageNode selector includesSubstring: 'True'.
 	conditionalJump := self
 		                   instantiateNoResultInstruction:
 		                   DRBranchIfCondition
 		                   operands: {
 				                   DREqualsThanComparison new.
 				                   self popOperand.
-				                   true asDRValue }.
+				                   bool asDRValue }.
 	self currentBasicBlock endInstruction: conditionalJump.
 
 	"Loop body. whileTrue: => jump if true to body"

--- a/Druid/DRIRGenerator.class.st
+++ b/Druid/DRIRGenerator.class.st
@@ -487,7 +487,6 @@ DRIRGenerator >> initializeSpecialCases [
 	specialCases at: #bitXor: put: #interpretBitXorWith:.
 	specialCases at: #anyMask: put: #interpretAnyMaskWith:.
 	specialCases at: #rotateLeft:by: put: #interpretRotateLeftBy:.
-	specialCases at: #bitShift: put: #interpretBitShiftWith:.
 		
 	"special simulation cases"
 	specialCases at: #cCode: put: #interpretCCodeInSmalltalkWith:.

--- a/Druid/DRInline.class.st
+++ b/Druid/DRInline.class.st
@@ -25,7 +25,7 @@ DRInline class >> enabled: aBoolean [
 ]
 
 { #category : 'system startup' }
-DRInline class >> startUp [ 
+DRInline class >> initialize [ 
 
 	enabled := true
 ]

--- a/Druid/DRInline.class.st
+++ b/Druid/DRInline.class.st
@@ -4,13 +4,30 @@ Class {
 	#instVars : [
 		'inlineGenerator'
 	],
+	#classInstVars : [
+		'enabled'
+	],
 	#category : 'Druid-Optimizations',
 	#package : 'Druid',
 	#tag : 'Optimizations'
 }
 
 { #category : 'accessing' }
+DRInline class >> enabled [
+
+	^ enabled
+]
+
+{ #category : 'accessing' }
+DRInline class >> enabled: aBoolean [ 
+
+	enabled := aBoolean 
+]
+
+{ #category : 'accessing' }
 DRInline >> doApply: cfg [
+
+	self class enabled ifFalse: [ ^ self ].
 
 	cfg messageSends copy do: [ :messageSend | 
 		self inline: messageSend ]

--- a/Druid/DRInline.class.st
+++ b/Druid/DRInline.class.st
@@ -29,7 +29,7 @@ DRInline >> doApply: cfg [
 
 	self class enabled ifFalse: [ ^ self ].
 
-	cfg messageSends copy do: [ :messageSend | 
+	(cfg messageSends takeFirst: 5) do: [ :messageSend | 
 		self inline: messageSend ]
 ]
 

--- a/Druid/DRInline.class.st
+++ b/Druid/DRInline.class.st
@@ -24,6 +24,12 @@ DRInline class >> enabled: aBoolean [
 	enabled := aBoolean 
 ]
 
+{ #category : 'system startup' }
+DRInline class >> startUp [ 
+
+	enabled := true
+]
+
 { #category : 'accessing' }
 DRInline >> doApply: cfg [
 

--- a/Druid/DRInstruction.class.st
+++ b/Druid/DRInstruction.class.st
@@ -771,7 +771,7 @@ DRInstruction >> supportConstantOperand [
 { #category : 'types' }
 DRInstruction >> typeWithAlreadySeen: aCollection [
 
-	^ DRSignedIntegerType size: 8 "Word size"
+	^ self subclassResponsibility
 ]
 
 { #category : 'users-definitions' }

--- a/Druid/DRLoadReceiver.class.st
+++ b/Druid/DRLoadReceiver.class.st
@@ -30,3 +30,9 @@ DRLoadReceiver >> sccpLatticeValueFor: sccp [
 	"We know that we know nothing about the frame pointer"
 	^ sccp bottom
 ]
+
+{ #category : 'types' }
+DRLoadReceiver >> typeWithAlreadySeen: aCollection [
+
+	^ DRSignedIntegerType bits64
+]

--- a/Druid/DRLoadStackValue.class.st
+++ b/Druid/DRLoadStackValue.class.st
@@ -58,3 +58,9 @@ DRLoadStackValue >> stackDepth [
 	stackDependencies ifEmpty: [ ^ 0 ].
 	^ stackDependencies anyOne stackDepth
 ]
+
+{ #category : 'types' }
+DRLoadStackValue >> typeWithAlreadySeen: aCollection [ 
+
+	^ DRSignedIntegerType bits64
+]

--- a/Druid/DRNegate.class.st
+++ b/Druid/DRNegate.class.st
@@ -29,3 +29,9 @@ DRNegate >> sccpOperateOnLattice: operand [
 	
 	^ operand negated
 ]
+
+{ #category : 'types' }
+DRNegate >> typeWithAlreadySeen: aCollection [
+
+	^ DRSignedIntegerType bits64
+]

--- a/Druid/DRPhysicalGeneralPurposeRegister.class.st
+++ b/Druid/DRPhysicalGeneralPurposeRegister.class.st
@@ -63,5 +63,5 @@ DRPhysicalGeneralPurposeRegister >> takeFromAllocator: aRegisterAllocator [
 { #category : 'types' }
 DRPhysicalGeneralPurposeRegister >> typeWithAlreadySeen: aCollection [
 
-	^ DRSignedIntegerType size: 8 "Word size"
+	^ DRSignedIntegerType bits64
 ]

--- a/Druid/DRPragmaBasedTypeSystem.class.st
+++ b/Druid/DRPragmaBasedTypeSystem.class.st
@@ -34,10 +34,3 @@ DRPragmaBasedTypeSystem >> receiverTypes: aDRMessageSend [
 			  ifFalse: [
 			  DRClassType for: (self class environment at: typeName) ] ]
 ]
-
-{ #category : 'asserting' }
-DRPragmaBasedTypeSystem >> shouldIgnore: aMethodNode [
-
-	^ aMethodNode isPrimitive or: [
-		aMethodNode sourceCode includesSubstring: #subclassResponsibility ]
-]

--- a/Druid/DRPragmaBasedTypeSystem.class.st
+++ b/Druid/DRPragmaBasedTypeSystem.class.st
@@ -34,3 +34,10 @@ DRPragmaBasedTypeSystem >> receiverTypes: aDRMessageSend [
 			  ifFalse: [
 			  DRClassType for: (self class environment at: typeName) ] ]
 ]
+
+{ #category : 'asserting' }
+DRPragmaBasedTypeSystem >> shouldIgnore: aMethodNode [
+
+	^ aMethodNode isPrimitive or: [
+		aMethodNode sourceCode includesSubstring: #subclassResponsibility ]
+]

--- a/Druid/DRSSARegister.class.st
+++ b/Druid/DRSSARegister.class.st
@@ -89,6 +89,6 @@ DRSSARegister >> rtlOperandQualifier [
 { #category : 'type' }
 DRSSARegister >> typeWithAlreadySeen: aCollection [
 	"Maybe this should be parametrised"
-
+1halt.
 	^ DRSignedIntegerType size: 8 "Word size"
 ]

--- a/Druid/DRSSARegister.class.st
+++ b/Druid/DRSSARegister.class.st
@@ -89,6 +89,6 @@ DRSSARegister >> rtlOperandQualifier [
 { #category : 'type' }
 DRSSARegister >> typeWithAlreadySeen: aCollection [
 	"Maybe this should be parametrised"
-1halt.
-	^ DRSignedIntegerType size: 8 "Word size"
+
+	^ DRSignedIntegerType bits64
 ]

--- a/Druid/DRStoreInstanceVariable.class.st
+++ b/Druid/DRStoreInstanceVariable.class.st
@@ -6,6 +6,12 @@ Class {
 	#tag : 'IR'
 }
 
+{ #category : 'as yet unclassified' }
+DRStoreInstanceVariable class >> loadInstructionKind [
+
+	^ DRLoadInstanceVariable 
+]
+
 { #category : 'visiting' }
 DRStoreInstanceVariable >> acceptVisitor: aVisitor [
 

--- a/Druid/DRStoreLiteralVariable.class.st
+++ b/Druid/DRStoreLiteralVariable.class.st
@@ -6,6 +6,12 @@ Class {
 	#tag : 'IR'
 }
 
+{ #category : 'as yet unclassified' }
+DRStoreLiteralVariable class >> loadInstructionKind [
+
+	^ DRLoadLiteralVariable 
+]
+
 { #category : 'visiting' }
 DRStoreLiteralVariable >> acceptVisitor: aVisitor [
 

--- a/Druid/DRStoreTemporaryVariable.class.st
+++ b/Druid/DRStoreTemporaryVariable.class.st
@@ -47,3 +47,9 @@ DRStoreTemporaryVariable >> storeValue [
 
 	^ self operand2
 ]
+
+{ #category : 'types' }
+DRStoreTemporaryVariable >> typeWithAlreadySeen: aCollection [
+
+	self error: 'Not implemented yet'
+]

--- a/Druid/DRStoreTemporaryVariable.class.st
+++ b/Druid/DRStoreTemporaryVariable.class.st
@@ -6,6 +6,12 @@ Class {
 	#tag : 'IR'
 }
 
+{ #category : 'as yet unclassified' }
+DRStoreTemporaryVariable class >> loadInstructionKind [
+
+	^ DRLoadTemporaryVariable 
+]
+
 { #category : 'visiting' }
 DRStoreTemporaryVariable >> acceptVisitor: aVisitor [
 

--- a/Druid/DRTypeSystem.class.st
+++ b/Druid/DRTypeSystem.class.st
@@ -29,6 +29,13 @@ DRTypeSystem >> receiverTypes: aDRMessageSend [
 	^ self subclassResponsibility
 ]
 
+{ #category : 'asserting' }
+DRTypeSystem >> shouldIgnore: aMethodNode [
+
+	^ aMethodNode isPrimitive or: [
+		aMethodNode sourceCode includesSubstring: #subclassResponsibility ]
+]
+
 { #category : 'as yet unclassified' }
 DRTypeSystem >> superMethodTupleForMessage: aDRMessageSend [
 

--- a/Druid/DRTypeSystem.class.st
+++ b/Druid/DRTypeSystem.class.st
@@ -11,14 +11,16 @@ DRTypeSystem >> methodsForMessage: aDRMessageSend [
 
 	| receiverTypes |
 	aDRMessageSend originAST isSuperSend ifTrue: [
-		^ { self superMethodTupleForMessage: aDRMessageSend } ].
+		^ { (self superMethodTupleForMessage: aDRMessageSend) } ].
 
 	receiverTypes := self receiverTypes: aDRMessageSend.
 	^ receiverTypes
 		  collect: [ :type |
-		  	type -> (type astForSelector: aDRMessageSend selector) ]
+		  type -> (type astForSelector: aDRMessageSend selector) ]
 		  thenReject: [ :assoc |
-		  	assoc value isNotNil and: [ assoc value isPrimitive ] ]
+			  assoc value
+				  ifNotNil: [ :m | self shouldIgnore: m ]
+				  ifNil: [ false ] ]
 ]
 
 { #category : 'API' }

--- a/Druid/DRUnsignedRightShift.class.st
+++ b/Druid/DRUnsignedRightShift.class.st
@@ -15,5 +15,5 @@ DRUnsignedRightShift >> acceptVisitor: aVisitor [
 { #category : 'types' }
 DRUnsignedRightShift >> typeWithAlreadySeen: aCollection [
 
-	^ DRUnsignedIntegerType size: 8 "bytes per word"
+	^ DRUnsignedIntegerType bits64
 ]


### PR DESCRIPTION
Starting https://github.com/Alamvic/druid/issues/246 to create an API to install compiled methods in the system and run benchmarks.

My idea is to re-compile a SMark benchemark (`benchMeteor`) and compare implementations. So far, I started to compile the class `BGMeteorBoard` and solving issues related with border cases.

In summary:
- Adding `DROpalCompiler` to use as API
- Fix https://github.com/Alamvic/druid/issues/254 by splitting writes and loads at the IR
- Fix other "small" issues (special cases)

## Now, we can recompile the `(DR)BGMeteorBoard`

### Without inlines

we can recompile all methods and get this result:
```
[BenchmarkGameSuite new benchMeteor] bench. 
"DRUID:    10 iterations in 5 seconds 133 milliseconds. 1.948 per second"
"ORIGINAL: 35 iterations in 5 seconds 88 milliseconds. 6.879 per second"
```

### With inlines

we get these compilation errors:
```
1. hasEastOrWestIsland:
Error: Non-local return on inlined method breaks the semantics
2. northIslandsFor:row:
Error: Invalid operand: a DRPhiFunction(t52 := Ø a DRNullValue a DRNullValue) in: a DRPhiFunction(t221 := Ø t52 t221)
3. findIsland:
Error: Non-local return on inlined method breaks the semantics
4. fillMaskStartingAt:stoppingAbove:ifFoundEnough:
Error: Non-local return on inlined method breaks the semantics
5. hasSouthIsland:
#ast was sent to nil
6. islandsFor:
Error: Non-local return on inlined method breaks the semantics
7. rotationsOf:do:
Error: Phi functions are not compiled
```

and even copying those methods, the bench cannot be executed (errors at execution). So we need to continue looking here.